### PR TITLE
Add Dependabot configuration for Docker image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,26 @@
 version: 2
 updates:
-  - package-ecosystem: "docker-compose"
+  # Monitor Docker images in stacks directory
+  - package-ecosystem: "docker"
     directory: "/stacks"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "docker"
+    commit-message:
+      prefix: "docker"
+      include: "scope"
+    reviewers:
+      - "salekseev"
+    # Group all docker image updates to reduce PR noise
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- Adds Dependabot configuration to automatically monitor and update Docker images in the `stacks/` directory
- Configured for weekly checks on Mondays at 9 AM
- Groups minor and patch updates together to reduce PR noise
- Automatically assigns PRs to @salekseev for review

## Configuration Details

The Dependabot configuration includes:
- **Package ecosystem**: Docker (monitors Docker Compose files)
- **Schedule**: Weekly on Mondays at 9:00 AM
- **PR limit**: Maximum 10 open PRs
- **Grouping**: Minor and patch updates are grouped into a single PR
- **Labels**: Auto-tagged with `dependencies` and `docker`
- **Reviewer**: Auto-assigned to @salekseev

## Benefits

- Automated security updates for Docker images
- Reduced manual effort in tracking image updates
- Grouped updates minimize notification noise
- Consistent update schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)