### PR TITLE
feat(hindsight): wire litellm to postgres for observability

### DIFF
--- a/stacks/hindsight.yaml
+++ b/stacks/hindsight.yaml
@@ -131,16 +131,17 @@ services:
   litellm:
     image: ghcr.io/berriai/litellm-non_root:v1.83.14-stable
     container_name: hindsight-litellm
-    command:
-      - "--port"
-      - "4000"
-      - "--config"
-      - "/app/config.yaml"
+    entrypoint:
+      - sh
+      - -c
+      - "set -a; . /run/secrets/hindsight_env; set +a; exec litellm --port 4000 --config /app/config.yaml"
     user: "568:568"
     cap_drop:
       - ALL
     security_opt:
       - no-new-privileges:true
+    secrets:
+      - hindsight_env
     environment:
       GITHUB_COPILOT_TOKEN_DIR: "/copilot-tokens"
       PRISMA_BINARY_CACHE_DIR: "/app/cache/prisma-python/binaries"
@@ -152,14 +153,17 @@ services:
     volumes:
       - /mnt/spool/apps/config/hindsight/litellm/config.yaml:/app/config.yaml:ro
       - /mnt/spool/apps/config/hindsight/litellm/copilot-tokens:/copilot-tokens
-    healthcheck:  # Defines the health check configuration for the container
+    depends_on:
+      hindsight-db:
+        condition: service_healthy
+    healthcheck:
       test:
         - CMD-SHELL
-        - python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')"  # Command to execute for health check
-      interval: 30s  # Perform health check every 30 seconds
-      timeout: 10s   # Health check command times out after 10 seconds
-      retries: 3     # Retry up to 3 times if health check fails
-      start_period: 40s  # Wait 40 seconds after container start before beginning health checks
+        - python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')"
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
     restart: unless-stopped
 
   tei-reranker:
@@ -208,6 +212,7 @@ configs:
       ALTER DATABASE postgres SET search_path = public, tokenizer_catalog, bm25_catalog;
       -- $$$$ → $$ inside compose (compose escapes a literal $ as $$).
       SELECT tokenizer_catalog.create_tokenizer('llmlingua2', $$$$ model = "llmlingua2" $$$$);
+      CREATE SCHEMA IF NOT EXISTS litellm AUTHORIZATION postgres;
   cloudflared:
     content: |
       tunnel: 5ebada53-82c5-40d9-baa6-030aa0d9ad75


### PR DESCRIPTION
## Summary

- Adds `entrypoint` to litellm service to source `DATABASE_URL` from `hindsight_env` secret at startup, enabling LiteLLM's Prisma DB backend
- Uses a dedicated `litellm` schema in the existing `hindsight-db` instance — no new container, no backup changes
- `depends_on: hindsight-db` ensures litellm waits for DB health before starting
- Bumps `start_period` from 40s → 90s to cover Prisma migration time on first boot
- Adds `CREATE SCHEMA IF NOT EXISTS litellm` to DB init SQL for future fresh deploys

## Host-side steps before redeploying

```bash
# 1. Pre-create schema (existing volume won't re-run init SQL)
docker exec hindsight-db psql -U postgres -d postgres \
  -c "CREATE SCHEMA IF NOT EXISTS litellm AUTHORIZATION postgres;"
```

Append to `/mnt/spool/apps/config/hindsight/env`:
```
DATABASE_URL=postgresql://postgres:PASSWORD@hindsight-db:5432/postgres?schema=litellm
```

Add to `/mnt/spool/apps/config/hindsight/litellm/config.yaml`:
```yaml
general_settings:
  master_key: "sk-..."
  ui_username: admin
  ui_password: "..."
  store_prompts_in_spend_logs: true
```

## Test plan

- [x] Pre-create schema, update env and config files, redeploy stack
- [ ] `docker logs hindsight-litellm` shows clean Prisma migration sequence
- [ ] `\dt litellm.*` in hindsight-db shows ~15 `LiteLLM_*` tables
- [ ] `https://hindsight-litellm.alekseev.us/ui` loads and accepts master key / credentials
- [ ] Trigger a hindsight recall → confirm row appears in UI Logs tab with `gemma-4-e4b`
- [ ] Force a bad model name → confirm error row captured with request/response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)