### PR TITLE
feat(hindsight): route LLM via ChatGPT subscription, qwen fallback

### DIFF
--- a/stacks/hindsight.yaml
+++ b/stacks/hindsight.yaml
@@ -41,10 +41,13 @@ services:
       HINDSIGHT_API_VECTOR_EXTENSION: vchord
       HINDSIGHT_API_TEXT_SEARCH_EXTENSION: vchord
       HINDSIGHT_API_BASE_PATH: /api
-      # API: default LLM (recall, reflect, consolidation) via local litellm proxy
+      # API: default LLM (recall, reflect, consolidation) via local litellm proxy.
+      # `hindsight-default` is a litellm alias (config.yaml on the host) routing
+      # to chatgpt/gpt-5.4-mini with fallback to qwen3.6-35b-think-general, so
+      # provider swaps don't require touching this stack.
       HINDSIGHT_API_LLM_PROVIDER: openai
       HINDSIGHT_API_LLM_BASE_URL: http://hindsight-litellm:4000/v1
-      HINDSIGHT_API_LLM_MODEL: qwen3.6-35b-think-general
+      HINDSIGHT_API_LLM_MODEL: hindsight-default
       # DB: bump asyncpg client timeout — pgvector ANN query in retain phase 1
       # exceeded the 60 s default once the facts table grew.
       HINDSIGHT_API_DB_COMMAND_TIMEOUT: "180"
@@ -128,7 +131,7 @@ services:
     restart: unless-stopped
 
   litellm:
-    image: ghcr.io/berriai/litellm-non_root:v1.83.14-stable
+    image: ghcr.io/berriai/litellm-non_root:v1.88.1
     container_name: hindsight-litellm
     entrypoint:
       - sh
@@ -143,6 +146,10 @@ services:
       - hindsight_env
     environment:
       GITHUB_COPILOT_TOKEN_DIR: "/copilot-tokens"
+      # ChatGPT-subscription (Codex OAuth) tokens for the native chatgpt/
+      # provider. First use triggers a device-code login printed to container
+      # logs; auth.json then auto-refreshes, so the mount must stay writable.
+      CHATGPT_TOKEN_DIR: "/chatgpt-tokens"
       PRISMA_BINARY_CACHE_DIR: "/app/cache/prisma-python/binaries"
       XDG_CACHE_HOME: "/app/cache"
       LITELLM_MIGRATION_DIR: "/app/migrations"
@@ -152,6 +159,7 @@ services:
     volumes:
       - /mnt/spool/apps/config/hindsight/litellm/config.yaml:/app/config.yaml:ro
       - /mnt/spool/apps/config/hindsight/litellm/copilot-tokens:/copilot-tokens
+      - /mnt/spool/apps/config/hindsight/litellm/chatgpt-tokens:/chatgpt-tokens
     depends_on:
       hindsight-db:
         condition: service_healthy


### PR DESCRIPTION
## Why

qwen3.6-35b backend erroring/timing out on Hindsight retain/recall. ChatGPT Business subscription now available — route through litellm's native `chatgpt/` provider (Codex OAuth) with qwen as fallback.

## Changes

- Bump litellm `v1.83.14-stable` → `v1.88.1` — old pin has the `chatgpt/` provider but misses responses-bridge fixes (BerriAI/litellm#26219)
- Add `CHATGPT_TOKEN_DIR=/chatgpt-tokens` + writable token volume (auth.json rewritten on auto-refresh)
- Hindsight model `qwen3.6-35b-think-general` → litellm alias `hindsight-default`, so provider swaps stay config-only

Model choice: `chatgpt/gpt-5.4-mini` — highest Business quota (60–350 msgs/5h), sized for extraction workloads. `gpt-5.5-instant` rejected by Codex backend for ChatGPT-account auth.

## Host steps before deploy (config outside repo)

1. `mkdir /mnt/spool/apps/config/hindsight/litellm/chatgpt-tokens && chown 568:568` it
2. `/mnt/spool/apps/config/hindsight/litellm/config.yaml`: add `hindsight-default` → `chatgpt/gpt-5.4-mini` to `model_list`; add `router_settings: fallbacks: [{hindsight-default: ["qwen3.6-35b-think-general"]}]`
3. Deploy, send one request through litellm, complete device-code login from `docker logs -f hindsight-litellm` within 15 min

## Verification

- [x] `./scripts/validate-stack.sh hindsight` passes
- [ ] Post-deploy: device login, test completion via alias, confirm chatgpt route in litellm spend logs
- [ ] First ingest: check fact extraction JSON (Codex backend drops `response_format` — litellm allowlist gap, BerriAI/litellm#24356)
- [ ] Fallback to qwen on 429/quota exhaustion

🤖 Generated with [Claude Code](https://claude.com/claude-code)