### PR TITLE
feat(hermes): port stack to gateway + Open WebUI + dashboard

### DIFF
--- a/docs/superpowers/plans/2026-06-30-hermes-gateway-openwebui-port.md
+++ b/docs/superpowers/plans/2026-06-30-hermes-gateway-openwebui-port.md
@@ -1,0 +1,403 @@
+# Hermes Gateway + Open WebUI + Dashboard Port — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the crash-looping `hermes-agent` source-populator + third-party `hermes-webui` with the first-party topology — a real `hermes gateway run` daemon (OpenAI API `:8642` + dashboard `:9119`) fronted by Open WebUI, keeping camofox + noVNC + cloudflared.
+
+**Architecture:** One `stacks/hermes.yaml` rewrite (4 services on `hermes-net`, no published ports, all access via cloudflared + one Cloudflare Access app). Repo-side work is a single compose rewrite validated with `validate-stack.sh`; runtime deploy + smoke tests are host-side on `silverstone` (the assistant cannot reach the host or Cloudflare).
+
+**Tech Stack:** Docker Compose, `nousresearch/hermes-agent` (gateway+dashboard), `open-webui`, `cloudflare/cloudflared`, `redf0x1/camofox-browser`, Portainer stack env-var interpolation.
+
+**Spec:** `docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md`
+
+---
+
+## File Structure
+
+- **Modify (full rewrite):** `stacks/hermes.yaml` — the 4-service target topology.
+- **Modify (1-line status note):** `docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md` — mark superseded, point to the new spec.
+- **No tests/scripts created** — verification is `./scripts/validate-stack.sh hermes` (static parse) + host-side smoke tests (Tasks 3–6).
+
+**Split of responsibility:** Tasks 1–2 are **repo-side, assistant-executable** on `master`. Tasks 3–6 are a **host-side operator runbook** run manually on `silverstone` via Portainer/Cloudflare — they are NOT assistant-executable and are written as action+verify checklists.
+
+---
+
+## Task 1: Rewrite `stacks/hermes.yaml` to the gateway + Open WebUI + dashboard topology
+
+**Files:**
+- Modify (replace entire contents): `stacks/hermes.yaml`
+- Verify with: `./scripts/validate-stack.sh hermes`
+
+- [ ] **Step 1: Replace the entire contents of `stacks/hermes.yaml` with:**
+
+```yaml
+# $schema: https://raw.githubusercontent.com/compose-spec/compose-spec/refs/heads/main/schema/compose-spec.json
+#
+# Hermes agent stack — first-party gateway + Open WebUI + dashboard.
+# See docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md
+# Secrets supplied via Portainer stack environment variables interpolated below ${VAR}.
+# Required Portainer stack env vars:
+#   CAMOFOX_SHARED_KEY        - camofox REST bearer (same secret on camofox + gateway)
+#   HERMES_API_SERVER_KEY     - bearer for the gateway OpenAI API :8642 (== Open WebUI OPENAI_API_KEY); >=8 chars
+#   HERMES_DASHBOARD_PASSWORD - dashboard basic-auth password (real 2nd factor behind Access)
+#   HERMES_DASHBOARD_SECRET   - dashboard token-signing key (openssl rand -base64 32)
+#   ANTHROPIC_TOKEN           - Claude OAuth setup-token (sk-ant-oat-...)
+#   HERMES_TUNNEL_ID          - Cloudflare tunnel UUID
+# Nothing published to host; only cloudflared reaches origins, gated by one Cloudflare Access app.
+
+services:
+
+  camofox:
+    restart: unless-stopped
+    # redf0x1 fork of jo-inc/camofox-browser: same REST API, but ships the noVNC stack.
+    # Server bearer = CAMOFOX_API_KEY (== CAMOFOX_SHARED_KEY). noVNC is on-demand via
+    # POST /sessions/<userId>/toggle-display; x11vnc -nopw, gated only by Cloudflare Access.
+    image: ghcr.io/redf0x1/camofox-browser:2.4.6
+    container_name: camofox
+    hostname: camofox
+    environment:
+      - CAMOFOX_HOST=0.0.0.0
+      - CAMOFOX_PORT=9377
+      - CAMOFOX_API_KEY=${CAMOFOX_SHARED_KEY}
+      - CAMOFOX_AUTH_MODE=required
+      - CAMOFOX_PROFILES_DIR=/home/node/.camofox/profiles
+      - CAMOFOX_VNC_HOST=0.0.0.0
+      - CAMOFOX_VNC_BASE_PORT=6080
+      - CAMOFOX_VNC_RESOLUTION=1920x1080x24
+      - CAMOFOX_HEADLESS=virtual
+      - CAMOFOX_VNC_TIMEOUT_MS=900000
+    volumes:
+      - /mnt/spool/apps/data/hermes/camofox:/home/node/.camofox
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:9377/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - hermes-net
+
+  hermes-gateway:
+    restart: unless-stopped
+    # First-party agent daemon. `gateway run` serves the OpenAI-compatible API on :8642 and
+    # (HERMES_DASHBOARD=1) the dashboard on :9119 as a co-resident s6-rc service. s6 supervises
+    # both, so a mis-start restarts in-container (no Docker crash-loop).
+    #
+    # Image pinned by digest: the ONLY published image carrying BOTH the camofox bearer-auth fix
+    # (#20476, merged to main 2026-06-29) and the gateway sleep/PATH crash fix (#36208). No release
+    # tag has both yet. STOPGAP — migrate to the first tag > v2026.6.19 containing commit babd916:
+    #   gh api repos/NousResearch/hermes-agent/compare/babd916...<tag> --jq '{status,behind_by}'
+    #   docker buildx imagetools inspect docker.io/nousresearch/hermes-agent:<tag> --format '{{.Manifest.Digest}}'
+    image: nousresearch/hermes-agent@sha256:c30340ee58dde86c284864b1016f474ec48c4a70ed49d24920cab083f670f417
+    container_name: hermes-gateway
+    hostname: hermes-gateway
+    command: gateway run
+    depends_on:
+      camofox:
+        condition: service_healthy
+    environment:
+      # /opt/data (HERMES_HOME) is chowned to this uid/gid by the image's s6 init.
+      - HERMES_UID=1000
+      - HERMES_GID=1000
+      # OpenAI-compatible API server (consumed by Open WebUI)
+      - API_SERVER_ENABLED=true
+      - API_SERVER_HOST=0.0.0.0
+      - API_SERVER_KEY=${HERMES_API_SERVER_KEY}
+      # First-party dashboard — fail-closed on a non-loopback bind, so basic-auth is REQUIRED.
+      - HERMES_DASHBOARD=1
+      - HERMES_DASHBOARD_HOST=0.0.0.0
+      - HERMES_DASHBOARD_PORT=9119
+      - HERMES_DASHBOARD_BASIC_AUTH_USERNAME=admin
+      - HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=${HERMES_DASHBOARD_PASSWORD}
+      - HERMES_DASHBOARD_BASIC_AUTH_SECRET=${HERMES_DASHBOARD_SECRET}
+      # NEVER set HERMES_DASHBOARD_INSECURE (bypasses the auth gate).
+      # Route all browser tools server-side through the camofox sidecar (same vars as before).
+      - CAMOFOX_URL=http://camofox:9377
+      - CAMOFOX_API_KEY=${CAMOFOX_SHARED_KEY}
+      - CAMOFOX_USER_ID=operator
+      - CAMOFOX_SESSION_KEY=visible-tab
+      - CAMOFOX_ADOPT_EXISTING_TAB=true
+      # Claude via OAuth setup-token (see spec §9 for the daemon-expiry runbook).
+      - ANTHROPIC_TOKEN=${ANTHROPIC_TOKEN}
+    volumes:
+      - /mnt/spool/apps/data/hermes/gateway:/opt/data
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9119/api/status',timeout=5).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    networks:
+      - hermes-net
+
+  open-webui:
+    restart: unless-stopped
+    # Daily chat client -> gateway /v1. No published ports: trusted-header SSO is only safe
+    # because nothing but cloudflared can reach :8080 to forge Cf-Access-Authenticated-User-Email.
+    image: ghcr.io/open-webui/open-webui:v0.10.1
+    container_name: open-webui
+    hostname: open-webui
+    depends_on:
+      hermes-gateway:
+        condition: service_healthy
+    environment:
+      - ENABLE_OPENAI_API=true
+      - OPENAI_API_BASE_URL=http://hermes-gateway:8642/v1
+      - OPENAI_API_KEY=${HERMES_API_SERVER_KEY}
+      - ENABLE_OLLAMA_API=false
+      - WEBUI_AUTH=true
+      - ENABLE_SIGNUP=false
+      - ENABLE_LOGIN_FORM=false
+      - WEBUI_AUTH_TRUSTED_EMAIL_HEADER=Cf-Access-Authenticated-User-Email
+      - WEBUI_AUTH_TRUSTED_NAME_HEADER=Cf-Access-Authenticated-User-Email
+      - WEBUI_URL=https://hermes.alekseev.us
+      - ENABLE_WEBSOCKET_SUPPORT=true
+      - CORS_ALLOW_ORIGIN=https://hermes.alekseev.us
+    volumes:
+      - /mnt/spool/apps/data/hermes/open-webui:/app/backend/data
+    networks:
+      - hermes-net
+
+  cloudflared:
+    restart: unless-stopped
+    image: cloudflare/cloudflared:2026.6.1
+    container_name: hermes-cloudflared
+    hostname: hermes-cloudflared
+    command: --config /etc/cloudflared/config.yml tunnel run
+    user: "568:568"
+    configs:
+      - source: cloudflared
+        target: /etc/cloudflared/config.yml
+        uid: "568"
+        gid: "568"
+        mode: 0440
+    volumes:
+      - /mnt/spool/apps/config/hermes/cloudflared:/etc/cloudflared/creds
+    depends_on:
+      - open-webui
+      - hermes-gateway
+      - camofox
+    networks:
+      - hermes-net
+
+configs:
+  cloudflared:
+    content: |
+      tunnel: ${HERMES_TUNNEL_ID}
+      credentials-file: /etc/cloudflared/creds/tunnel.json
+      ingress:
+        # Origin-side Cloudflare Access JWT validation. All three hosts share ONE Access app /
+        # audTag (team alekseev); cloudflared verifies Cf-Access-Jwt-Assertion against the team
+        # JWKS + audTag before proxying.
+        - hostname: hermes.alekseev.us
+          service: http://open-webui:8080
+          access:
+            required: true
+            teamName: alekseev
+            audTag:
+              - f79eba4208644c03e8777ab7870842bc46887458b09d3ad19e74570b119bc37d
+        - hostname: hermes-dashboard.alekseev.us
+          service: http://hermes-gateway:9119
+          access:
+            required: true
+            teamName: alekseev
+            audTag:
+              - f79eba4208644c03e8777ab7870842bc46887458b09d3ad19e74570b119bc37d
+        - hostname: hermes-browser.alekseev.us
+          service: http://camofox:6080
+          access:
+            required: true
+            teamName: alekseev
+            audTag:
+              - f79eba4208644c03e8777ab7870842bc46887458b09d3ad19e74570b119bc37d
+        - service: http_status:404
+
+networks:
+  hermes-net:
+```
+
+- [ ] **Step 2: Validate the rewritten stack parses**
+
+Run: `./scripts/validate-stack.sh hermes`
+Expected: `Validation successful for stacks/hermes.yaml`. Unset-variable warnings (e.g. `The "HERMES_API_SERVER_KEY" variable is not set. Defaulting to a blank string.`) are printed to stderr and are **expected** — they don't fail validation (same behavior as the current file).
+
+- [ ] **Step 3: Confirm the rendered topology wiring**
+
+Run: `docker-compose -f stacks/hermes.yaml config 2>/dev/null | grep -E 'container_name|image:|8642|9119|8080|hermes-gateway:8642|camofox:9377'`
+Expected: shows `hermes-gateway`, `open-webui`, `camofox`, `hermes-cloudflared`; the `nousresearch/hermes-agent@sha256:c30340ee…` digest; `OPENAI_API_BASE_URL` = `http://hermes-gateway:8642/v1`; `CAMOFOX_URL` = `http://camofox:9377`. Confirm **no** `hermes-webui`, `hermes-agent`, or `hermes-agent-src` remain.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add stacks/hermes.yaml
+git commit -m "$(cat <<'EOF'
+feat(hermes): port stack to gateway + Open WebUI + dashboard
+
+Replace the crash-looping hermes-agent source-populator and third-party
+hermes-webui (+ hermes-agent-src volume) with a first-party hermes gateway
+daemon: OpenAI API :8642 + dashboard :9119 in one container, Open WebUI as
+the chat client (trusted-header SSO behind Cloudflare Access), camofox and
+noVNC unchanged. Image digest-pinned (only build with both #20476 + #36208
+fixes). Ref docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Mark the prior spec superseded
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md:5`
+
+- [ ] **Step 1: Insert a superseded pointer immediately under the `- **Status:**` line (line 5)**
+
+Add this line right after the existing `- **Status:** …` bullet at the top of the file:
+
+```markdown
+- **Superseded (UI/agent-runtime topology):** by `2026-06-30-hermes-gateway-openwebui-port-design.md` — the `hermes-webui` + `hermes-agent-src` in-process topology is replaced by `hermes gateway run` (API :8642 + dashboard :9119) + Open WebUI. Camofox / noVNC / cloudflared sections below still apply.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md
+git commit -m "$(cat <<'EOF'
+docs(hermes): mark webui-topology spec superseded by the gateway port
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 (OPERATOR, on `silverstone`): Provision secrets, dirs, and prune old state
+
+> Not assistant-executable. Run these on the host / in Portainer.
+
+- [ ] **Step 1: Create the new host data dirs (owned by uid/gid 1000)**
+
+```bash
+sudo mkdir -p /mnt/spool/apps/data/hermes/gateway /mnt/spool/apps/data/hermes/open-webui
+sudo chown -R 1000:1000 /mnt/spool/apps/data/hermes/gateway /mnt/spool/apps/data/hermes/open-webui
+```
+
+- [ ] **Step 2: Set/adjust Portainer stack environment variables**
+
+Add: `HERMES_API_SERVER_KEY` (≥8 chars random), `HERMES_DASHBOARD_PASSWORD` (strong, unique), `HERMES_DASHBOARD_SECRET` (`openssl rand -base64 32`).
+Keep: `CAMOFOX_SHARED_KEY`, `ANTHROPIC_TOKEN`, `HERMES_TUNNEL_ID`.
+Remove: `HERMES_WEBUI_PASSWORD` (and `VNC_PASSWORD` if still present).
+
+Generate the two new random secrets:
+```bash
+echo "HERMES_API_SERVER_KEY=$(openssl rand -hex 24)"
+echo "HERMES_DASHBOARD_SECRET=$(openssl rand -base64 32)"
+```
+Verify: the Portainer stack env list shows all six required vars and no `HERMES_WEBUI_PASSWORD`.
+
+---
+
+## Task 4 (OPERATOR): Cloudflare route + Access for `hermes-dashboard`
+
+> Not assistant-executable. Done in the Cloudflare dashboard.
+
+- [ ] **Step 1: Add the DNS/tunnel hostname**
+
+In the tunnel config, `hermes-dashboard.alekseev.us` is already routed by the inline cloudflared `ingress:` (Task 1) to `http://hermes-gateway:9119`. Create the corresponding **public hostname / CNAME** for `hermes-dashboard.alekseev.us` pointing at the tunnel (same as `hermes` / `hermes-browser`).
+
+- [ ] **Step 2: Attach it to the existing Access application**
+
+Add `hermes-dashboard.alekseev.us` to the **same** Cloudflare Access application already protecting `hermes` and `hermes-browser` (audTag `f79eba4208644c03e8777ab7870842bc46887458b09d3ad19e74570b119bc37d`, team `alekseev`).
+Verify: `curl -sI https://hermes-dashboard.alekseev.us` returns the Access login redirect (302 to the Access team domain), not a direct 200/404.
+
+- [ ] **Step 3 (hardening): tighten the Access policy**
+
+Because the dashboard grants full machine control (embedded shell, edits `.env`/API keys), set the Access policy to a specific identity/email and a short session TTL. Verify the policy lists only intended identities.
+
+---
+
+## Task 5 (OPERATOR): Deploy and seed model config
+
+> Not assistant-executable.
+
+- [ ] **Step 1: Redeploy the stack in Portainer (pull image)**
+
+Update the `hermes` stack from the new `stacks/hermes.yaml`, with "Re-pull image" enabled. The old `hermes-agent` and `hermes-webui` containers are removed; `hermes-gateway` and `open-webui` are created.
+
+- [ ] **Step 2: Verify the gateway started cleanly (no crash-loop)**
+
+```bash
+docker ps --filter name=hermes-gateway --format '{{.Status}}'   # expect: Up ... (healthy) after ~1 min
+docker logs --tail 50 hermes-gateway                            # expect: gateway + dashboard services up; NO restart loop, NO FileNotFoundError
+```
+
+- [ ] **Step 3: Seed the model provider config (if not already set)**
+
+```bash
+docker exec hermes-gateway sh -c 'cat >> /opt/data/config.yaml <<"YAML"
+model:
+  provider: anthropic
+  default: claude-opus-4-8   # confirm the exact id the anthropic adapter accepts
+YAML'
+docker restart hermes-gateway
+```
+Verify: `docker exec hermes-gateway cat /opt/data/config.yaml` shows the `model:` block.
+
+- [ ] **Step 4: Prune the orphaned old volume (after confirming the new stack works)**
+
+```bash
+docker volume ls | grep hermes-agent-src   # if present and orphaned:
+docker volume rm hermes-agent-src
+```
+
+---
+
+## Task 6 (OPERATOR): Smoke tests
+
+> Not assistant-executable. Run after Task 5.
+
+- [ ] **Step 1: Dashboard auth gate is engaged**
+
+```bash
+docker exec hermes-gateway python3 -c "import urllib.request,json; print(json.load(urllib.request.urlopen('http://localhost:9119/api/status',timeout=5)))"
+```
+Expected: JSON with `auth_required: true` and `basic` among `auth_providers`.
+
+- [ ] **Step 2: Gateway API exposes the model**
+
+```bash
+docker exec hermes-gateway python3 -c "import os,urllib.request; r=urllib.request.Request('http://localhost:8642/v1/models',headers={'Authorization':'Bearer '+os.environ['API_SERVER_KEY']}); print(urllib.request.urlopen(r,timeout=5).read().decode())"
+```
+Expected: a JSON model list (200), not 401/404.
+
+- [ ] **Step 3: Open WebUI loads and auto-logs-in**
+
+Browse `https://hermes.alekseev.us` → Cloudflare Access → Open WebUI loads without a second login (trusted-header SSO); the Hermes model appears in the model picker. Confirm the first auto-provisioned user has the **admin** role (Admin → Users).
+
+- [ ] **Step 4: Chat reaches Claude**
+
+Send a plain prompt in Open WebUI. Expected: a streamed Claude response (validates `ANTHROPIC_TOKEN` + model id).
+
+- [ ] **Step 5: Browser tool runs server-side through camofox**
+
+Ask the agent to open a benign page (e.g. "what's on example.com"). Expected: it returns real rendered content; `docker logs --tail 30 camofox` shows an authenticated REST hit on `:9377` (no 403).
+
+- [ ] **Step 6: noVNC login-handoff still works**
+
+Follow the existing runbook: `POST /sessions/operator/toggle-display` → open `https://hermes-browser.alekseev.us/vnc.html?autoconnect=true&resize=scale` through Access → log in by hand → the agent's next browse reuses the `operator` profile.
+
+- [ ] **Step 7: Dashboard is reachable and authenticated**
+
+Browse `https://hermes-dashboard.alekseev.us` → Access → basic-auth prompt (user `admin` / `HERMES_DASHBOARD_PASSWORD`) → Sessions / Cron / Config tabs load.
+
+---
+
+## Self-Review (completed by planner)
+
+- **Spec coverage:** §4 topology → Task 1 compose; §5.2 gateway env → Task 1; §5.3 open-webui env → Task 1; §5.4 cloudflared ingress → Task 1; §6 secrets → Task 3; §8 image pin → Task 1 (digest + migration note); §9 OAuth → Task 5 seed + spec runbook; §10 migration split → Tasks 1–2 (repo) / 3–6 (host); §11 validation → Task 6; §12 risks → surfaced in Task 5 (crash-loop check) and Task 6.
+- **Placeholder scan:** none — the full compose, exact env, and exact verify commands are inline. The only deferred item is the model id (explicitly flagged "confirm the exact id").
+- **Type/name consistency:** `HERMES_API_SERVER_KEY` is the single source used by both `API_SERVER_KEY` (gateway) and `OPENAI_API_KEY` (open-webui); `CAMOFOX_SHARED_KEY` used by both camofox and gateway; audTag identical across all three ingress rules; no dangling `hermes-webui`/`hermes-agent-src` references.
+```

--- a/docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md
+++ b/docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md
@@ -1,0 +1,366 @@
+# Hermes Gateway + Open WebUI + Dashboard Port — Design Spec
+
+- **Date:** 2026-06-30
+- **Status:** Approved (brainstorm) — supersedes `2026-06-30-hermes-stealth-browser-stack-design.md` for the UI/agent-runtime topology
+- **Stack file:** `stacks/hermes.yaml` (to be rewritten)
+- **Author:** brainstormed with Claude Code (ultracode)
+- **Supersedes:** the `hermes-webui` + `hermes-agent-src` two-container topology (§1/§4/§5.2 of the prior spec). Camofox, cloudflared, Cloudflare Access, and the noVNC login-handoff carry over unchanged.
+
+---
+
+## 1. Goal & what changes
+
+Replace the fragile third-party UI + source-volume bridge with the **official first-party** Hermes topology:
+
+- **Before:** a `hermes-agent` container existed only to `chmod` and populate the `hermes-agent-src` volume with agent *source*, which the third-party `nesquena/hermes-webui` `rsync`-staged and `pip install`ed to run the agent **in-process**. That source-populator container had no legitimate long-lived foreground and **crash-looped** (5 fixes deep, each surfacing a new coupling — an architectural smell, not a bug).
+- **After:** a real `hermes-gateway` daemon (`nousresearch/hermes-agent`, `command: gateway run`) that (a) serves the **OpenAI-compatible API** on `:8642` and (b) runs the **first-party Hermes dashboard** on `:9119` in the *same* container (`HERMES_DASHBOARD=1`, supervised s6-rc service). **Open WebUI** is the daily chat client pointed at `:8642/v1`. The `hermes-agent-src` volume, the `chmod`/`rsync` bridge, and the whole crash-loop class are **deleted**.
+
+**Why this is not "port the agent, keep the UI":** `nesquena/hermes-webui` runs the agent in-process and does **not** consume the gateway API for chat (gateway-decoupling, webui issue #2491, is unshipped). So porting necessarily replaces the UI. Open WebUI covers daily chat; the Hermes **dashboard** (Sessions, Cron, Config, API Keys, Profiles, Skills, embedded Chat/TUI) recovers the Hermes-aware surface that plain Open WebUI lacks. Together they cover everything `hermes-webui` did, first-party.
+
+## 2. Non-goals / out of scope (Phase 2, unchanged)
+
+- Hindsight semantic memory provider (Hermes built-in memory covers v1).
+- 1Password agent-driven login (human noVNC login + persistent camofox profile remains the credential model).
+- Messaging adapters (Telegram/Discord/Slack/WhatsApp) — the gateway runs **API-server-only**; adapters stay opt-in/off.
+- Residential egress proxy for camofox.
+- No custom images; no host port publishing; all external access via cloudflared + Cloudflare Access.
+
+## 3. Key decisions (and why)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Agent runtime | **`hermes gateway run` daemon** | First-party, s6-supervised; the API server + dashboard are its actual purpose. Eliminates the source-populator crash-loop. |
+| Chat UI | **Open WebUI** (`ghcr.io/open-webui/open-webui`) | Officially documented Hermes integration; generic OpenAI-compatible client; well-maintained. |
+| Admin/Hermes-aware UI | **Hermes dashboard** (`HERMES_DASHBOARD=1`, same container) | Recovers Sessions/Cron/Config/Profiles/Skills that Open WebUI lacks; first-party. |
+| Claude credential | **OAuth token `ANTHROPIC_TOKEN`** (user choice) | Uses Claude Max + extra-usage credits. Daemon caveat: static setup-token expires → silent outage; evaluate the refreshable `~/.claude/.credentials.json` variant (§9). |
+| Image pin | **`nousresearch/hermes-agent@sha256:c30340ee…`** (digest) | Only published image with **both** the camofox bearer fix (#20476) and the gateway sleep/PATH crash fix (#36208). Stopgap until a tag `> v2026.6.19` (§8). |
+| UI auth posture | **Cloudflare Access is the gate (lean)** | Open WebUI via trusted-header SSO (no second login); dashboard gets a strong basic-auth password as the real second factor behind Access. One identity source. |
+| Dashboard exposure | **`hermes-dashboard.alekseev.us` + harden** | User choice. Dashboard is a full machine-control surface (embedded shell, edits `.env`/`config.yaml`), so Access policy must be tight and the basic-auth password strong. |
+| External access | **cloudflared + Cloudflare Access, one app for all 3 hosts** | `hermes`, `hermes-dashboard`, `hermes-browser` share one Access app / audTag (`f79eba42…`, team `alekseev`); cloudflared validates the Access JWT origin-side (`access:` block). |
+| Camofox | **unchanged** (`ghcr.io/redf0x1/camofox-browser:2.4.6`) | Browsing path + noVNC handoff verified working; the UI swap doesn't touch it. |
+
+## 4. Architecture
+
+Four services on the private `hermes-net`. Nothing published to the host; only cloudflared reaches the origins, and only via Cloudflare Access.
+
+```
+                             Internet
+                                │
+                    Cloudflare Access  (one app, audTag f79eba42…, team alekseev)
+                                │
+        ┌───────────────────────┼───────────────────────────┐   cloudflared
+        ▼                       ▼                             ▼
+ hermes.alekseev.us    hermes-dashboard.alekseev.us   hermes-browser.alekseev.us
+        │                       │                             │
+        ▼                       ▼                             ▼
+  ┌───────────┐         ┌────────────────────────┐     ┌──────────────┐
+  │ open-webui│  /v1    │     hermes-gateway      │     │   camofox    │
+  │  :8080    │────────▶│  :8642  OpenAI API      │     │ :9377 REST   │
+  │ trusted-  │         │  :9119  dashboard       │────▶│ :6080 noVNC  │
+  │ header SSO│         │  gateway run + s6       │ tools│ (unchanged) │
+  └───────────┘         │  HERMES_DASHBOARD=1     │     └──────────────┘
+                        │  /opt/data (HERMES_HOME)│         ▲
+                        │  CAMOFOX_* + ANTHROPIC  │─────────┘ server-side browser tools
+                        └────────────────────────┘
+                          private docker network "hermes-net"
+```
+
+## 5. Component specifications
+
+### 5.1 `camofox` — unchanged
+`ghcr.io/redf0x1/camofox-browser:2.4.6`, REST `:9377` (bearer `CAMOFOX_API_KEY` = `CAMOFOX_SHARED_KEY`, `/health` open), on-demand noVNC `:6080` (`x11vnc -nopw`, gated by Access). Env, volume (`/mnt/spool/apps/data/hermes/camofox`), and healthcheck are carried over verbatim from the current stack. The noVNC login-handoff runbook (`POST /sessions/operator/toggle-display`) is unaffected.
+
+### 5.2 `hermes-gateway` — agent daemon (API + dashboard)
+- **Image:** `nousresearch/hermes-agent@sha256:c30340ee58dde86c284864b1016f474ec48c4a70ed49d24920cab083f670f417` (see §8).
+- **Command:** `gateway run` (image entrypoint `/init` s6 supervises the gateway + dashboard services).
+- **Volume:** `/mnt/spool/apps/data/hermes/gateway` → `/opt/data` (`HERMES_HOME`/`HERMES_WRITE_SAFE_ROOT`; holds `config.yaml`, `.env`, `lazy-packages`, session SQLite; persists across image upgrades). **Fresh** host dir — do not reuse the old `hermes-webui` config home.
+- **Ports:** none published; `:8642` and `:9119` reached over `hermes-net` (Open WebUI → `:8642`, cloudflared → `:9119`).
+- **Env:**
+  | Var | Value | Notes |
+  |---|---|---|
+  | `HERMES_UID` / `HERMES_GID` | `1000` / `1000` | Own `/opt/data` as the host dir owner (s6 init chowns HERMES_HOME). Validate at deploy. |
+  | `API_SERVER_ENABLED` | `true` | Turn on the OpenAI-compatible server (default false → would 404). |
+  | `API_SERVER_HOST` | `0.0.0.0` | Reachable by Open WebUI over the network. |
+  | `API_SERVER_KEY` | `${HERMES_API_SERVER_KEY}` | Bearer for `:8642` (≥8 chars). **Must equal** Open WebUI's `OPENAI_API_KEY`. |
+  | `HERMES_DASHBOARD` | `1` | Enable the dashboard s6 service. |
+  | `HERMES_DASHBOARD_HOST` | `0.0.0.0` | Docker default; reached by cloudflared. |
+  | `HERMES_DASHBOARD_PORT` | `9119` | Default. |
+  | `HERMES_DASHBOARD_BASIC_AUTH_USERNAME` | `admin` | Activates the basic-auth provider (satisfies the fail-closed non-loopback gate). |
+  | `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD` | `${HERMES_DASHBOARD_PASSWORD}` | Strong, unique — the real second factor behind Access. (`_PASSWORD_HASH` scrypt is preferred if we want no plaintext at rest.) |
+  | `HERMES_DASHBOARD_BASIC_AUTH_SECRET` | `${HERMES_DASHBOARD_SECRET}` | Token-signing key, 32+ random bytes (`openssl rand -base64 32`). |
+  | `CAMOFOX_URL` | `http://camofox:9377` | Route all browser tools server-side through camofox. |
+  | `CAMOFOX_API_KEY` | `${CAMOFOX_SHARED_KEY}` | Bearer camofox expects (same secret). |
+  | `CAMOFOX_USER_ID` | `operator` | Externally-managed mode (no destructive cleanup). |
+  | `CAMOFOX_SESSION_KEY` | `visible-tab` | Tab match key for adoption. |
+  | `CAMOFOX_ADOPT_EXISTING_TAB` | `true` | Reuse the human-authenticated tab. |
+  | `ANTHROPIC_TOKEN` | `${ANTHROPIC_TOKEN}` | Claude OAuth setup-token (see §9). |
+  - **NEVER** set `HERMES_DASHBOARD_INSECURE` (bypasses the auth gate).
+  - **Seeded `config.yaml`** on `/opt/data` (or via dashboard Config tab): `model.provider: anthropic` + a default model id (e.g. `claude-opus-4-8`; confirm the exact id Hermes' anthropic adapter accepts at deploy).
+- **Healthcheck:** `python3 -c` GET on `http://localhost:9119/api/status` (python3 is in-image; avoids assuming curl). Confirm path/behavior at deploy.
+
+### 5.3 `open-webui` — daily chat client
+- **Image:** `ghcr.io/open-webui/open-webui:v0.10.1` (pin a version; `:main` is rolling and can lag releases — confirm the current stable at deploy).
+- **Ports:** none published (`expose: 8080` only). **This is load-bearing:** trusted-header SSO is safe *only* because no client can reach the container directly to forge the header.
+- **Volume:** `/mnt/spool/apps/data/hermes/open-webui` → `/app/backend/data`.
+- **Env:**
+  ```
+  ENABLE_OPENAI_API=true
+  OPENAI_API_BASE_URL=http://hermes-gateway:8642/v1
+  OPENAI_API_KEY=${HERMES_API_SERVER_KEY}       # == gateway API_SERVER_KEY
+  ENABLE_OLLAMA_API=false
+  WEBUI_AUTH=true                                # MUST stay true for trusted-header SSO
+  ENABLE_SIGNUP=false
+  ENABLE_LOGIN_FORM=false
+  WEBUI_AUTH_TRUSTED_EMAIL_HEADER=Cf-Access-Authenticated-User-Email
+  WEBUI_AUTH_TRUSTED_NAME_HEADER=Cf-Access-Authenticated-User-Email
+  WEBUI_URL=https://hermes.alekseev.us
+  ENABLE_WEBSOCKET_SUPPORT=true                  # required for streaming (v0.5+)
+  CORS_ALLOW_ORIGIN=https://hermes.alekseev.us
+  ```
+- **depends_on:** `hermes-gateway` (prefer `service_healthy`).
+
+### 5.4 `cloudflared` — tunnel + origin-side Access validation
+- Image/user/creds unchanged (`cloudflare/cloudflared:2026.6.1`, user `568:568`, creds bind, inline `configs:`).
+- **Ingress (all three hosts share one Access app / audTag `f79eba42…`, team `alekseev`):**
+  ```
+  ingress:
+    - hostname: hermes.alekseev.us
+      service: http://open-webui:8080
+      access: { required: true, teamName: alekseev, audTag: [f79eba42…] }
+    - hostname: hermes-dashboard.alekseev.us
+      service: http://hermes-gateway:9119
+      access: { required: true, teamName: alekseev, audTag: [f79eba42…] }
+    - hostname: hermes-browser.alekseev.us
+      service: http://camofox:6080
+      access: { required: true, teamName: alekseev, audTag: [f79eba42…] }
+    - service: http_status:404
+  ```
+- **depends_on:** `open-webui`, `hermes-gateway`, `camofox`.
+
+## 6. Secrets & auth model
+
+Portainer stack `${VAR}` interpolation (no host `.env`; every secret is a discrete env var).
+
+| Secret | Used by | Status |
+|---|---|---|
+| `CAMOFOX_SHARED_KEY` | camofox `CAMOFOX_API_KEY` + gateway `CAMOFOX_API_KEY` | keep |
+| `HERMES_API_SERVER_KEY` | gateway `API_SERVER_KEY` == open-webui `OPENAI_API_KEY` | **new** |
+| `HERMES_DASHBOARD_PASSWORD` | gateway dashboard basic-auth | **new** |
+| `HERMES_DASHBOARD_SECRET` | gateway dashboard token-signing | **new** |
+| `ANTHROPIC_TOKEN` | gateway Claude credential | keep |
+| `HERMES_TUNNEL_ID` + tunnel creds file | cloudflared | keep |
+| `HERMES_WEBUI_PASSWORD`, `VNC_PASSWORD` | — | **dropped** |
+
+**Auth model:** Cloudflare Access authenticates every request at the edge; cloudflared re-validates the Access JWT origin-side before proxying. Open WebUI trusts `Cf-Access-Authenticated-User-Email` (auto-provisions the first email as admin — validate). The dashboard basic-auth password is the second factor on the privileged surface. Tighten the Access policy (specific identity, short session TTL) since the dashboard grants full machine control.
+
+## 7. Data flow (all three preserved)
+
+1. **Chat:** `hermes.alekseev.us` → Access → open-webui → `POST hermes-gateway:8642/v1/chat/completions` → the gateway-side agent runs tools and reasons **server-side** → SSE stream back to Open WebUI.
+2. **Browser tool:** the agent drives `camofox:9377` with the bearer (same `CAMOFOX_*`) — stealth browsing runs server-side on the gateway; Open WebUI just renders the conversation.
+3. **noVNC login-handoff:** `hermes-browser.alekseev.us` → camofox `:6080`; operator toggles the display and logs in; camofox persists the `operator` profile; the agent adopts it. **Unchanged.**
+
+## 8. Image pinning strategy
+
+- No release tag carries both required fixes: `v2026.6.19` (latest tag) has the gateway sleep/PATH fix (#36208/PR#37120) but **not** the camofox bearer fix (#20476/PR#54729, merged to `main` 2026-06-29, after the tag).
+- Pin the multi-arch **index digest** `sha256:c30340ee58dde86c284864b1016f474ec48c4a70ed49d24920cab083f670f417` (`:latest`/`:main` as of 2026-06-30T20:55Z; amd64 `98f7bb45…`, arm64 `c6494c76…`). It tracks unreleased `main` (~1303 commits past the tag) — treat as a **stopgap**.
+- **Action:** watch `gh release list`; migrate to the first tag `> v2026.6.19` containing commit `babd916`. Re-verify with `gh api …/compare/babd916...<tag>` and `docker buildx imagetools inspect` before bumping. Bumping is no longer coupled to deleting any volume (the `hermes-agent-src` volume is gone).
+
+## 9. Claude credential (OAuth token) — daemon caveat & runbook
+
+The user chose the OAuth setup-token (`ANTHROPIC_TOKEN=sk-ant-oat-…`). For a long-lived daemon this expires and causes a **silent chat outage** until re-provisioned. Two mitigations to evaluate at implementation:
+
+1. **Refreshable credentials file (preferred if supported):** drop a Claude Code `~/.claude/.credentials.json` (with `refreshToken`) onto the gateway's `/opt/data` HOME so the anthropic adapter auto-refreshes. Confirm the pinned image honors this.
+2. **Re-provision runbook:** `claude setup-token` on the workstation → update the Portainer `ANTHROPIC_TOKEN` env → redeploy. Document expiry monitoring.
+
+(Billing caveat unchanged: third-party-tool OAuth is extra-usage since 2026-04-04; Agent-SDK usage draws a separate credit pool since 2026-06-15.)
+
+## 10. Migration (repo-side vs host-side)
+
+- **Repo-side (assistant, on `master`):** rewrite `stacks/hermes.yaml` to the topology above; `./scripts/validate-stack.sh hermes`; commit. Update/annotate the prior spec as superseded.
+- **Host-side on `silverstone` (operator, manual — assistant cannot reach host/Cloudflare):**
+  1. Portainer env: add `HERMES_API_SERVER_KEY`, `HERMES_DASHBOARD_PASSWORD`, `HERMES_DASHBOARD_SECRET`; remove `HERMES_WEBUI_PASSWORD`.
+  2. Create `/mnt/spool/apps/data/hermes/gateway` and `/mnt/spool/apps/data/hermes/open-webui` (owned uid 1000).
+  3. Cloudflare: add `hermes-dashboard.alekseev.us` DNS/tunnel route and attach it to the existing Access app (same audTag).
+  4. Redeploy (old `hermes-agent`/`hermes-webui` containers + `hermes-agent-src` volume removed; new volumes created).
+  5. Seed `/opt/data/config.yaml` (`model.provider: anthropic` + model id); provision `ANTHROPIC_TOKEN`.
+  6. Smoke tests (§11).
+
+## 11. Testing & validation
+
+1. **Static:** `./scripts/validate-stack.sh hermes` (compose parse).
+2. **Gateway boot:** no crash-loop; `curl -s http://<host>:9119/api/status | jq '.auth_required,.auth_providers'` → `true` + `basic`.
+3. **Open WebUI:** loads at `hermes.alekseev.us` through Access; auto-logs in via trusted header (confirm admin role); the Hermes model appears under `/v1/models`.
+4. **Chat:** a prompt returns a Claude response (credential reachable, model id valid).
+5. **Browser tool:** a browse task routes through camofox `:9377` (bearer, no 403) and returns rendered content.
+6. **noVNC handoff:** `hermes-browser.alekseev.us` toggle-display → login → agent adopts the `operator` session.
+7. **Dashboard:** `hermes-dashboard.alekseev.us` prompts basic-auth; Sessions/Cron/Config visible.
+
+## 12. Risks / validate-at-deploy
+
+- **Digest pin is a mutable-`main` stopgap** — less release hardening; migrate to the next tag (§8).
+- **OAuth token expiry → silent outage** (§9); evaluate refreshable creds; monitor.
+- **Hermes duplicate-`tool_use`-id transcript bug** (Anthropic adapter, wedges after ~50-message compaction) may bite long Open WebUI chats on this image; validate, mitigate with shorter sessions until fixed upstream.
+- **Open WebUI trusted-header = full auth bypass if any host port is published** — design keeps zero published ports; verify. Also: first-user-admin/role provisioning quirks (#6548/#21016) and a past CSP-behind-Cloudflare-Tunnel bug — validate the pinned version loads end-to-end through the tunnel.
+- **`HERMES_DASHBOARD_INSECURE` semantics contradict across docs** — never set it; verify the gate via `/api/status`.
+- **`/opt/data` uid/permissions** on first mount — confirm the image's uid remap (`HERMES_UID`/`HERMES_GID`).
+- **Health endpoint paths** (`:9119/api/status`, `:8642` liveness) — confirm against the pinned image.
+- **`config.yaml` provider seeding vs env-only** — confirm whether `ANTHROPIC_TOKEN` env alone suffices or `hermes auth add anthropic` / a seeded provider block is needed.
+
+## 13. Appendix — reference compose (design target; finalized in the implementation plan)
+
+```yaml
+# $schema: https://raw.githubusercontent.com/compose-spec/compose-spec/refs/heads/main/schema/compose-spec.json
+# Hermes gateway + Open WebUI + dashboard. Secrets via Portainer stack env ${VAR}.
+# Required env: CAMOFOX_SHARED_KEY, HERMES_API_SERVER_KEY, HERMES_DASHBOARD_PASSWORD,
+#               HERMES_DASHBOARD_SECRET, ANTHROPIC_TOKEN, HERMES_TUNNEL_ID.
+services:
+
+  camofox:
+    # UNCHANGED — see current stack for full env/healthcheck (redf0x1 fork, :9377 REST, :6080 on-demand noVNC).
+    restart: unless-stopped
+    image: ghcr.io/redf0x1/camofox-browser:2.4.6
+    container_name: camofox
+    hostname: camofox
+    environment:
+      - CAMOFOX_HOST=0.0.0.0
+      - CAMOFOX_PORT=9377
+      - CAMOFOX_API_KEY=${CAMOFOX_SHARED_KEY}
+      - CAMOFOX_AUTH_MODE=required
+      - CAMOFOX_PROFILES_DIR=/home/node/.camofox/profiles
+      - CAMOFOX_VNC_HOST=0.0.0.0
+      - CAMOFOX_VNC_BASE_PORT=6080
+      - CAMOFOX_VNC_RESOLUTION=1920x1080x24
+      - CAMOFOX_HEADLESS=virtual
+      - CAMOFOX_VNC_TIMEOUT_MS=900000
+    volumes:
+      - /mnt/spool/apps/data/hermes/camofox:/home/node/.camofox
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:9377/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks: [hermes-net]
+
+  hermes-gateway:
+    restart: unless-stopped
+    image: nousresearch/hermes-agent@sha256:c30340ee58dde86c284864b1016f474ec48c4a70ed49d24920cab083f670f417
+    container_name: hermes-gateway
+    hostname: hermes-gateway
+    command: gateway run
+    depends_on:
+      camofox:
+        condition: service_healthy
+    environment:
+      - HERMES_UID=1000
+      - HERMES_GID=1000
+      # OpenAI-compatible API server (for Open WebUI)
+      - API_SERVER_ENABLED=true
+      - API_SERVER_HOST=0.0.0.0
+      - API_SERVER_KEY=${HERMES_API_SERVER_KEY}
+      # First-party dashboard (fail-closed on non-loopback -> basic-auth required)
+      - HERMES_DASHBOARD=1
+      - HERMES_DASHBOARD_HOST=0.0.0.0
+      - HERMES_DASHBOARD_PORT=9119
+      - HERMES_DASHBOARD_BASIC_AUTH_USERNAME=admin
+      - HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=${HERMES_DASHBOARD_PASSWORD}
+      - HERMES_DASHBOARD_BASIC_AUTH_SECRET=${HERMES_DASHBOARD_SECRET}
+      # Camofox browser tools (server-side)
+      - CAMOFOX_URL=http://camofox:9377
+      - CAMOFOX_API_KEY=${CAMOFOX_SHARED_KEY}
+      - CAMOFOX_USER_ID=operator
+      - CAMOFOX_SESSION_KEY=visible-tab
+      - CAMOFOX_ADOPT_EXISTING_TAB=true
+      # Claude via OAuth setup-token
+      - ANTHROPIC_TOKEN=${ANTHROPIC_TOKEN}
+    volumes:
+      - /mnt/spool/apps/data/hermes/gateway:/opt/data
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9119/api/status',timeout=5).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    networks: [hermes-net]
+
+  open-webui:
+    restart: unless-stopped
+    image: ghcr.io/open-webui/open-webui:v0.10.1
+    container_name: open-webui
+    hostname: open-webui
+    depends_on:
+      hermes-gateway:
+        condition: service_healthy
+    environment:
+      - ENABLE_OPENAI_API=true
+      - OPENAI_API_BASE_URL=http://hermes-gateway:8642/v1
+      - OPENAI_API_KEY=${HERMES_API_SERVER_KEY}
+      - ENABLE_OLLAMA_API=false
+      - WEBUI_AUTH=true
+      - ENABLE_SIGNUP=false
+      - ENABLE_LOGIN_FORM=false
+      - WEBUI_AUTH_TRUSTED_EMAIL_HEADER=Cf-Access-Authenticated-User-Email
+      - WEBUI_AUTH_TRUSTED_NAME_HEADER=Cf-Access-Authenticated-User-Email
+      - WEBUI_URL=https://hermes.alekseev.us
+      - ENABLE_WEBSOCKET_SUPPORT=true
+      - CORS_ALLOW_ORIGIN=https://hermes.alekseev.us
+    volumes:
+      - /mnt/spool/apps/data/hermes/open-webui:/app/backend/data
+    networks: [hermes-net]
+
+  cloudflared:
+    restart: unless-stopped
+    image: cloudflare/cloudflared:2026.6.1
+    container_name: hermes-cloudflared
+    hostname: hermes-cloudflared
+    command: --config /etc/cloudflared/config.yml tunnel run
+    user: "568:568"
+    configs:
+      - source: cloudflared
+        target: /etc/cloudflared/config.yml
+        uid: "568"
+        gid: "568"
+        mode: 0440
+    volumes:
+      - /mnt/spool/apps/config/hermes/cloudflared:/etc/cloudflared/creds
+    depends_on:
+      - open-webui
+      - hermes-gateway
+      - camofox
+    networks: [hermes-net]
+
+configs:
+  cloudflared:
+    content: |
+      tunnel: ${HERMES_TUNNEL_ID}
+      credentials-file: /etc/cloudflared/creds/tunnel.json
+      ingress:
+        # Origin-side Cloudflare Access JWT validation. All three hosts share ONE
+        # Access app / audTag (team alekseev). cloudflared verifies Cf-Access-Jwt-Assertion
+        # against the team JWKS + audTag before proxying.
+        - hostname: hermes.alekseev.us
+          service: http://open-webui:8080
+          access:
+            required: true
+            teamName: alekseev
+            audTag:
+              - f79eba4208644c03e8777ab7870842bc46887458b09d3ad19e74570b119bc37d
+        - hostname: hermes-dashboard.alekseev.us
+          service: http://hermes-gateway:9119
+          access:
+            required: true
+            teamName: alekseev
+            audTag:
+              - f79eba4208644c03e8777ab7870842bc46887458b09d3ad19e74570b119bc37d
+        - hostname: hermes-browser.alekseev.us
+          service: http://camofox:6080
+          access:
+            required: true
+            teamName: alekseev
+            audTag:
+              - f79eba4208644c03e8777ab7870842bc46887458b09d3ad19e74570b119bc37d
+        - service: http_status:404
+
+networks:
+  hermes-net:
+```

--- a/docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md
+++ b/docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-06-30
 - **Branch:** `hermes-stealth-browser-stack`
 - **Status:** Deployed 2026-06-30 — agent↔camofox path verified; Cloudflare Access + noVNC login-handoff pending
+- **Superseded (UI/agent-runtime topology):** by `2026-06-30-hermes-gateway-openwebui-port-design.md` — the `hermes-webui` + `hermes-agent-src` in-process topology is replaced by `hermes gateway run` (API :8642 + dashboard :9119) + Open WebUI. Camofox / noVNC / cloudflared sections below still apply.
 - **Stack file (to be created):** `stacks/hermes.yaml`
 - **Author:** brainstormed with Claude Code (ultracode)
 

--- a/stacks/hermes.yaml
+++ b/stacks/hermes.yaml
@@ -1,44 +1,41 @@
 # $schema: https://raw.githubusercontent.com/compose-spec/compose-spec/refs/heads/main/schema/compose-spec.json
 #
-# Hermes stealth-browser agent stack. See docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md
-# Secrets are supplied via Portainer stack environment variables and interpolated below as ${VAR}.
+# Hermes agent stack — first-party gateway + Open WebUI + dashboard.
+# See docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md
+# Secrets supplied via Portainer stack environment variables interpolated below ${VAR}.
 # Required Portainer stack env vars:
-#   CAMOFOX_SHARED_KEY      - REST bearer; same secret on camofox (CAMOFOX_API_KEY) and hermes (CAMOFOX_API_KEY)
-#   HERMES_WEBUI_PASSWORD   - password for the Hermes web UI
-#   (VNC_PASSWORD is no longer used: redf0x1 runs x11vnc -nopw; the noVNC viewer is gated by Cloudflare Access)
-#   ANTHROPIC_TOKEN         - Claude OAuth token (sk-ant-oat-...) or use ANTHROPIC_API_KEY instead
-#   HERMES_TUNNEL_ID        - Cloudflare tunnel UUID
-# Nothing is published to the host; only the UI and noVNC are reachable via cloudflared + Cloudflare Access.
+#   CAMOFOX_SHARED_KEY        - camofox REST bearer (same secret on camofox + gateway)
+#   HERMES_API_SERVER_KEY     - bearer for the gateway OpenAI API :8642 (== Open WebUI OPENAI_API_KEY); >=8 chars
+#   HERMES_DASHBOARD_PASSWORD - dashboard basic-auth password (real 2nd factor behind Access)
+#   HERMES_DASHBOARD_SECRET   - dashboard token-signing key (openssl rand -base64 32)
+#   ANTHROPIC_TOKEN           - Claude OAuth setup-token (sk-ant-oat-...)
+#   HERMES_TUNNEL_ID          - Cloudflare tunnel UUID
+# Nothing published to host; only cloudflared reaches origins, gated by one Cloudflare Access app.
 
 services:
 
   camofox:
     restart: unless-stopped
-    # redf0x1 fork of jo-inc/camofox-browser. Same REST API (verified Hermes-compatible drop-in)
-    # but this image actually SHIPS the noVNC stack (x11vnc/websockify/noVNC) — jo-inc :1.11.2
-    # shipped it broken/absent (issues #4314/#4933; fix unreleased). Auth: redf0x1's SERVER reads
-    # the bearer from CAMOFOX_API_KEY (jo-inc used CAMOFOX_ACCESS_KEY) — same secret Hermes sends.
-    # noVNC is ON-DEMAND: POST /sessions/<userId>/toggle-display switches that context to a virtual
-    # display + starts VNC (auto-expires after CAMOFOX_VNC_TIMEOUT_MS). x11vnc runs -nopw, so the
-    # viewer is gated ONLY by Cloudflare Access on hermes-browser.alekseev.us.
+    # redf0x1 fork of jo-inc/camofox-browser: same REST API, but ships the noVNC stack.
+    # Server bearer = CAMOFOX_API_KEY (== CAMOFOX_SHARED_KEY). noVNC is on-demand via
+    # POST /sessions/<userId>/toggle-display; x11vnc -nopw, gated only by Cloudflare Access.
     image: ghcr.io/redf0x1/camofox-browser:2.4.6
     container_name: camofox
     hostname: camofox
     environment:
-      - CAMOFOX_HOST=0.0.0.0                    # REST bind reachable from hermes-webui (default 127.0.0.1)
+      - CAMOFOX_HOST=0.0.0.0
       - CAMOFOX_PORT=9377
-      - CAMOFOX_API_KEY=${CAMOFOX_SHARED_KEY}   # server bearer; SAME secret Hermes sends (also CAMOFOX_API_KEY)
-      - CAMOFOX_AUTH_MODE=required              # enforce the bearer key on all networked requests
+      - CAMOFOX_API_KEY=${CAMOFOX_SHARED_KEY}
+      - CAMOFOX_AUTH_MODE=required
       - CAMOFOX_PROFILES_DIR=/home/node/.camofox/profiles
-      - CAMOFOX_VNC_HOST=0.0.0.0                # noVNC web port reachable from cloudflared (default localhost)
+      - CAMOFOX_VNC_HOST=0.0.0.0
       - CAMOFOX_VNC_BASE_PORT=6080
-      - CAMOFOX_VNC_RESOLUTION=1920x1080x24     # avoids the 1x1 Xvfb trap
-      - CAMOFOX_HEADLESS=virtual                # headed-in-Xvfb (stronger anti-detect than true-headless)
-      - CAMOFOX_VNC_TIMEOUT_MS=900000           # keep display/VNC up 15 min for the human login-handoff (confirm var name)
+      - CAMOFOX_VNC_RESOLUTION=1920x1080x24
+      - CAMOFOX_HEADLESS=virtual
+      - CAMOFOX_VNC_TIMEOUT_MS=900000
     volumes:
       - /mnt/spool/apps/data/hermes/camofox:/home/node/.camofox
     healthcheck:
-      # node is always present in this image; avoids assuming curl/wget exist.
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:9377/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
@@ -47,71 +44,84 @@ services:
     networks:
       - hermes-net
 
-  hermes-agent:
+  hermes-gateway:
     restart: unless-stopped
-    image: nousresearch/hermes-agent:latest
-    container_name: hermes-agent
-    hostname: hermes-agent
-    # Supplies the Hermes agent SOURCE (/opt/hermes) into the hermes-agent-src volume so
-    # hermes-webui can pip-install + import it. Idle gateway peer; needs no model creds.
-    # NOTE: :latest (not a release tag) on purpose. The Camofox bearer-auth fix (#20476:
-    # CAMOFOX_API_KEY -> "Authorization: Bearer") landed on main 2026-06-29, AFTER the newest
-    # release tag v2026.6.19 (which sends NO auth header -> 401 from the camofox sidecar).
-    # Repin to the first release tag > v2026.6.19 once it ships. Bumping this image also
-    # requires deleting the hermes-agent-src volume so the new source repopulates.
-    # Run as root and make the source tree world-readable before handing off to s6 (/init).
-    # The :latest image ships /opt/hermes/.playwright and .venv as root-owned, non-readable
-    # files; that breaks hermes-webui's `rsync` staging of the source as uid 1000
-    # (agent issues #23402 / #27221). `a+rX` adds read + dir-traverse only (no +x on files).
-    # s6 still drops the gateway service to HERMES_UID. Self-heals whenever the volume is
-    # (re)populated from a new agent image.
-    user: "0:0"
-    entrypoint: ["/bin/sh", "-c"]
-    # chmod the source readable for the webui rsync, then hand off to the image's REAL entrypoint
-    # (/init + main-wrapper.sh). Execing `/init gateway run` was wrong — there's no `gateway` on PATH,
-    # so s6 logged "rc.init: gateway: not found" and the container crash-looped (exit 127).
-    command: ["chmod -R a+rX /opt/hermes 2>/dev/null || true; exec /init /opt/hermes/docker/main-wrapper.sh"]
-    environment:
-      - HERMES_HOME=/home/hermes/.hermes
-      - HERMES_UID=1000
-      - HERMES_GID=1000
-    volumes:
-      - /mnt/spool/apps/config/hermes/home:/home/hermes/.hermes
-      - hermes-agent-src:/opt/hermes
-    networks:
-      - hermes-net
-
-  hermes-webui:
-    restart: unless-stopped
-    image: ghcr.io/nesquena/hermes-webui:0.51.760
-    container_name: hermes-webui
-    hostname: hermes-webui
-    # Web dashboard + the in-process agent; agent SOURCE comes from the hermes-agent-src volume.
+    # First-party agent daemon. `gateway run` serves the OpenAI-compatible API on :8642 and
+    # (HERMES_DASHBOARD=1) the dashboard on :9119 as a co-resident s6-rc service. s6 supervises
+    # both, so a mis-start restarts in-container (no Docker crash-loop).
+    #
+    # Image pinned by digest: the ONLY published image carrying BOTH the camofox bearer-auth fix
+    # (#20476, merged to main 2026-06-29) and the gateway sleep/PATH crash fix (#36208). No release
+    # tag has both yet. STOPGAP — migrate to the first tag > v2026.6.19 containing commit babd916:
+    #   gh api repos/NousResearch/hermes-agent/compare/babd916...<tag> --jq '{status,behind_by}'
+    #   docker buildx imagetools inspect docker.io/nousresearch/hermes-agent:<tag> --format '{{.Manifest.Digest}}'
+    image: nousresearch/hermes-agent@sha256:c30340ee58dde86c284864b1016f474ec48c4a70ed49d24920cab083f670f417
+    container_name: hermes-gateway
+    hostname: hermes-gateway
+    command: gateway run
     depends_on:
       camofox:
         condition: service_healthy
-      hermes-agent:
-        condition: service_started
     environment:
-      - HERMES_WEBUI_HOST=0.0.0.0
-      - HERMES_WEBUI_PORT=8787
-      - HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui   # required by init; persists under the mounted ~/.hermes
-      - HERMES_API_URL=http://hermes-agent:8642                  # gateway status pill (chat still runs in-process here)
-      - HERMES_WEBUI_PASSWORD=${HERMES_WEBUI_PASSWORD}
-      - WANTED_UID=1000           # must own /mnt/spool/apps/config/hermes/home
-      - WANTED_GID=1000
-      # Route all agent browser tools through the camofox sidecar over its REST API.
+      # /opt/data (HERMES_HOME) is chowned to this uid/gid by the image's s6 init.
+      - HERMES_UID=1000
+      - HERMES_GID=1000
+      # OpenAI-compatible API server (consumed by Open WebUI)
+      - API_SERVER_ENABLED=true
+      - API_SERVER_HOST=0.0.0.0
+      - API_SERVER_KEY=${HERMES_API_SERVER_KEY}
+      # First-party dashboard — fail-closed on a non-loopback bind, so basic-auth is REQUIRED.
+      - HERMES_DASHBOARD=1
+      - HERMES_DASHBOARD_HOST=0.0.0.0
+      - HERMES_DASHBOARD_PORT=9119
+      - HERMES_DASHBOARD_BASIC_AUTH_USERNAME=admin
+      - HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=${HERMES_DASHBOARD_PASSWORD}
+      - HERMES_DASHBOARD_BASIC_AUTH_SECRET=${HERMES_DASHBOARD_SECRET}
+      # NEVER set HERMES_DASHBOARD_INSECURE (bypasses the auth gate).
+      # Route all browser tools server-side through the camofox sidecar (same vars as before).
       - CAMOFOX_URL=http://camofox:9377
-      - CAMOFOX_API_KEY=${CAMOFOX_SHARED_KEY}   # client bearer; MUST equal camofox's CAMOFOX_API_KEY (same secret)
-      - CAMOFOX_USER_ID=operator                # stable id -> externally-managed mode (no destructive cleanup)
+      - CAMOFOX_API_KEY=${CAMOFOX_SHARED_KEY}
+      - CAMOFOX_USER_ID=operator
       - CAMOFOX_SESSION_KEY=visible-tab
-      - CAMOFOX_ADOPT_EXISTING_TAB=true         # reuse the human-authenticated tab instead of creating a new one
-      # Claude credential. OAuth setup-token (sk-ant-oat-...) via ANTHROPIC_TOKEN, or swap for ANTHROPIC_API_KEY.
+      - CAMOFOX_ADOPT_EXISTING_TAB=true
+      # Claude via OAuth setup-token (see spec §9 for the daemon-expiry runbook).
       - ANTHROPIC_TOKEN=${ANTHROPIC_TOKEN}
     volumes:
-      - /mnt/spool/apps/config/hermes/home:/home/hermeswebui/.hermes
-      - hermes-agent-src:/home/hermeswebui/.hermes/hermes-agent:ro   # agent source (populated by hermes-agent); webui installs from it
-      - /mnt/spool/apps/data/hermes/workspace:/workspace
+      - /mnt/spool/apps/data/hermes/gateway:/opt/data
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9119/api/status',timeout=5).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    networks:
+      - hermes-net
+
+  open-webui:
+    restart: unless-stopped
+    # Daily chat client -> gateway /v1. No published ports: trusted-header SSO is only safe
+    # because nothing but cloudflared can reach :8080 to forge Cf-Access-Authenticated-User-Email.
+    image: ghcr.io/open-webui/open-webui:v0.10.1
+    container_name: open-webui
+    hostname: open-webui
+    depends_on:
+      hermes-gateway:
+        condition: service_healthy
+    environment:
+      - ENABLE_OPENAI_API=true
+      - OPENAI_API_BASE_URL=http://hermes-gateway:8642/v1
+      - OPENAI_API_KEY=${HERMES_API_SERVER_KEY}
+      - ENABLE_OLLAMA_API=false
+      - WEBUI_AUTH=true
+      - ENABLE_SIGNUP=false
+      - ENABLE_LOGIN_FORM=false
+      - WEBUI_AUTH_TRUSTED_EMAIL_HEADER=Cf-Access-Authenticated-User-Email
+      - WEBUI_AUTH_TRUSTED_NAME_HEADER=Cf-Access-Authenticated-User-Email
+      - WEBUI_URL=https://hermes.alekseev.us
+      - ENABLE_WEBSOCKET_SUPPORT=true
+      - CORS_ALLOW_ORIGIN=https://hermes.alekseev.us
+    volumes:
+      - /mnt/spool/apps/data/hermes/open-webui:/app/backend/data
     networks:
       - hermes-net
 
@@ -131,7 +141,8 @@ services:
     volumes:
       - /mnt/spool/apps/config/hermes/cloudflared:/etc/cloudflared/creds
     depends_on:
-      - hermes-webui
+      - open-webui
+      - hermes-gateway
       - camofox
     networks:
       - hermes-net
@@ -142,13 +153,18 @@ configs:
       tunnel: ${HERMES_TUNNEL_ID}
       credentials-file: /etc/cloudflared/creds/tunnel.json
       ingress:
-        # Origin-side Cloudflare Access JWT validation (cloudflared verifies the
-        # Cf-Access-Jwt-Assertion against the team JWKS + audTag before proxying).
-        # NOTE: audTag must match each hostname's Access application. If hermes and
-        # hermes-browser are SEPARATE Access apps, give each its own AUD (the value
-        # below is what you provided "for both" — replace hermes-browser's if it differs).
+        # Origin-side Cloudflare Access JWT validation. All three hosts share ONE Access app /
+        # audTag (team alekseev); cloudflared verifies Cf-Access-Jwt-Assertion against the team
+        # JWKS + audTag before proxying.
         - hostname: hermes.alekseev.us
-          service: http://hermes-webui:8787
+          service: http://open-webui:8080
+          access:
+            required: true
+            teamName: alekseev
+            audTag:
+              - f79eba4208644c03e8777ab7870842bc46887458b09d3ad19e74570b119bc37d
+        - hostname: hermes-dashboard.alekseev.us
+          service: http://hermes-gateway:9119
           access:
             required: true
             teamName: alekseev
@@ -165,6 +181,3 @@ configs:
 
 networks:
   hermes-net:
-
-volumes:
-  hermes-agent-src:


### PR DESCRIPTION
## Summary
- Replace the crash-looping `hermes-agent` source-populator + third-party `hermes-webui` (and the `hermes-agent-src` rsync/volume bridge) with the first-party topology.
- New `hermes-gateway` (`nousresearch/hermes-agent`, `gateway run`): OpenAI-compatible API on `:8642` + Hermes dashboard on `:9119` in one container. Image **digest-pinned** — the only published build carrying both the camofox bearer fix (#20476) and the gateway sleep/PATH crash fix (#36208); no release tag has both yet.
- New `open-webui` chat client → gateway `/v1`, trusted-header SSO behind Cloudflare Access.
- camofox + noVNC unchanged; cloudflared gains the `hermes-dashboard.alekseev.us` route on the shared Access app/audTag.
- Spec: `docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md`; Plan: `docs/superpowers/plans/2026-06-30-hermes-gateway-openwebui-port.md`.

## Test Plan
- [x] `./scripts/validate-stack.sh hermes` passes (static parse)
- [x] Host (silverstone): provision `HERMES_API_SERVER_KEY` / `HERMES_DASHBOARD_PASSWORD` / `HERMES_DASHBOARD_SECRET`; create `gateway` + `open-webui` data dirs (uid 1000)
- [x] Cloudflare: add `hermes-dashboard.alekseev.us` to the tunnel + existing Access app
- [ ] Deploy; `hermes-gateway` healthy (no crash-loop); `/api/status` → `auth_required:true` + `basic`
- [ ] Open WebUI loads via `hermes.alekseev.us` (trusted-header SSO), model listed, chat reaches Claude
- [ ] Browse task routes through camofox (no 403); noVNC handoff works; dashboard reachable at `hermes-dashboard.alekseev.us`

🤖 Generated with [Claude Code](https://claude.com/claude-code)