### PR TITLE
feat(hermes): Phase-2 Hindsight semantic memory over shared-services

### DIFF
--- a/docs/superpowers/plans/2026-07-01-hermes-hindsight-phase2.md
+++ b/docs/superpowers/plans/2026-07-01-hermes-hindsight-phase2.md
@@ -1,0 +1,332 @@
+# Hermes ↔ Hindsight Memory (Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire Hermes' native `hindsight` memory provider to the self-hosted Hindsight stack over a shared Docker network, so the gateway agent gets semantic recall/retain on top of its built-in Markdown memory.
+
+**Architecture:** Both stacks are edited to join a new host-created external Docker network `shared-services`; `hermes-gateway` reaches Hindsight's REST dataplane by container name at `http://hindsight:8888/api`. Connection params are Portainer `${VAR}` env; the provider is switched on once via `config.yaml` (no env selector exists). Runtime deploy is a manual host runbook (spec §10) — the repo tasks below only change and statically validate the two compose files + reconcile docs.
+
+**Tech Stack:** Docker Compose, `scripts/validate-stack.sh` (wraps `docker-compose config`), Portainer stack env vars.
+
+**Spec:** `docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md`
+
+**Pre-flight facts (verified while writing this plan):**
+- `docker-compose config` returns exit 0 for a stack referencing an `external: true` network that does not exist yet — so validation passes in the repo without creating the host network.
+- Unset `${VAR}` prints a `level=warning … not set` line to stderr but still exits 0; `validate-stack.sh` prints `Validation successful` on success.
+- `hindsight.yaml` currently has **no** top-level `networks:` block and the `hindsight` service has **no** `networks:` key (implicitly on the compose default network). Re-listing `default` when adding an explicit list keeps db/litellm/tei DNS working — confirmed rendering both `default` and `shared-services` on the service.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `stacks/hindsight.yaml` | Modify | Attach the `hindsight` service to `shared-services` (keep it on `default`). |
+| `stacks/hermes.yaml` | Modify | Attach `hermes-gateway` to `shared-services`; add `HINDSIGHT_*` env; document the new required Portainer var. |
+| `docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md` | Modify | One-line as-built pointer: Phase-2 Hindsight now implemented. |
+| `docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md` | Modify | Same as-built pointer. |
+
+Deploy-time (host, **not** a repo task): follow spec §10 runbook — `docker network create shared-services`, copy the tenant key into the `HINDSIGHT_API_KEY` Portainer var, redeploy both stacks, `hermes config set memory.provider hindsight`, run spec §9 checks.
+
+---
+
+### Task 1: Attach the `hindsight` service to `shared-services`
+
+**Files:**
+- Modify: `stacks/hindsight.yaml` (the `hindsight` service block at lines 74-80; add a new top-level `networks:` block after the `secrets:` block at EOF, lines 280-284)
+
+- [ ] **Step 1: Write the failing assertion and run it**
+
+The "test" is that the rendered config attaches `hindsight` to `shared-services`. Run:
+
+```bash
+docker-compose -f stacks/hindsight.yaml config 2>/dev/null | grep -q 'shared-services' && echo PRESENT || echo ABSENT
+```
+
+Expected: `ABSENT` (not wired yet).
+
+- [ ] **Step 2: Add the `networks:` key to the `hindsight` service**
+
+Edit `stacks/hindsight.yaml`. Find this exact block (lines 74-80):
+
+```yaml
+    expose:
+      - "8888"
+      - "9999"
+    depends_on:
+      hindsight-db:
+        condition: service_healthy
+    restart: unless-stopped
+```
+
+Replace it with (adds `networks:` — `default` re-listed so db/litellm/tei stay reachable):
+
+```yaml
+    expose:
+      - "8888"
+      - "9999"
+    depends_on:
+      hindsight-db:
+        condition: service_healthy
+    restart: unless-stopped
+    # Phase-2: also join the host-created shared-services net so the hermes stack can
+    # reach this dataplane by container name (http://hindsight:8888/api). `default` is
+    # re-listed explicitly so siblings (hindsight-db, litellm, tei-*) stay reachable.
+    networks:
+      - default
+      - shared-services
+```
+
+- [ ] **Step 3: Add the top-level `networks:` block**
+
+Edit `stacks/hindsight.yaml`. Find the `secrets:` block at EOF (lines 280-284):
+
+```yaml
+secrets:
+  hindsight_db_password:
+    file: /mnt/spool/apps/config/hindsight/secrets/db_password
+  hindsight_env:
+    file: /mnt/spool/apps/config/hindsight/env
+```
+
+Append a `networks:` block immediately after it:
+
+```yaml
+secrets:
+  hindsight_db_password:
+    file: /mnt/spool/apps/config/hindsight/secrets/db_password
+  hindsight_env:
+    file: /mnt/spool/apps/config/hindsight/env
+
+networks:
+  # Created out-of-band on the host: `docker network create shared-services`.
+  # Shared with the hermes stack so hermes-gateway resolves `hindsight` by name.
+  shared-services:
+    external: true
+```
+
+- [ ] **Step 4: Validate and re-run the assertion — expect PASS**
+
+```bash
+./scripts/validate-stack.sh hindsight
+docker-compose -f stacks/hindsight.yaml config 2>/dev/null | grep -q 'shared-services' && echo PRESENT || echo ABSENT
+docker-compose -f stacks/hindsight.yaml config 2>/dev/null \
+  | awk '/^  hindsight:/{f=1} f&&/networks:/{print;p=1;next} p&&/- |: null/{print} /^  hindsight-db:/{f=0;p=0}' | head
+```
+
+Expected:
+- `Validating stacks/hindsight.yaml...` then `Validation successful for stacks/hindsight.yaml` (unset-variable warnings on stderr are fine).
+- `PRESENT`
+- The awk snippet shows the `hindsight` service listing both `default` and `shared-services`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add stacks/hindsight.yaml
+git commit -m "$(printf 'feat(hindsight): attach dataplane to shared-services network\n\nPhase-2 Hindsight<->Hermes wiring: adds an external shared-services\nnetwork and joins the hindsight service to it (default re-listed so\ninternal DNS is preserved) so hermes-gateway can reach the dataplane\nby container name.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 2: Wire `hermes-gateway` to Hindsight (network + env + docs header)
+
+**Files:**
+- Modify: `stacks/hermes.yaml` (header comment line 12; `hermes-gateway` env after line 88; `hermes-gateway` networks lines 97-98; top-level `networks:` lines 182-183)
+
+- [ ] **Step 1: Write the failing assertion and run it**
+
+```bash
+docker-compose -f stacks/hermes.yaml config 2>/dev/null | grep -q 'hindsight:8888/api' && echo PRESENT || echo ABSENT
+```
+
+Expected: `ABSENT`.
+
+- [ ] **Step 2: Document the new required Portainer var in the header**
+
+Edit `stacks/hermes.yaml`. Find (lines 12-13):
+
+```yaml
+#   HERMES_TUNNEL_ID          - Cloudflare tunnel UUID
+# Nothing published to host; only cloudflared reaches origins, gated by one Cloudflare Access app.
+```
+
+Replace with:
+
+```yaml
+#   HERMES_TUNNEL_ID          - Cloudflare tunnel UUID
+#   HINDSIGHT_API_KEY         - Hindsight tenant key (== server HINDSIGHT_API_TENANT_API_KEY); Phase-2 memory
+# Nothing published to host; only cloudflared reaches origins, gated by one Cloudflare Access app.
+```
+
+- [ ] **Step 3: Add the `HINDSIGHT_*` env vars to `hermes-gateway`**
+
+Edit `stacks/hermes.yaml`. Find (lines 87-90):
+
+```yaml
+      # Claude via OAuth setup-token (see spec §9 for the daemon-expiry runbook).
+      - ANTHROPIC_TOKEN=${ANTHROPIC_TOKEN}
+    volumes:
+      - /mnt/spool/apps/data/hermes/gateway:/opt/data
+```
+
+Replace with:
+
+```yaml
+      # Claude via OAuth setup-token (see spec §9 for the daemon-expiry runbook).
+      - ANTHROPIC_TOKEN=${ANTHROPIC_TOKEN}
+      # Phase-2 Hindsight semantic memory — AUGMENTS (does not replace) built-in Markdown memory.
+      # Reaches the self-hosted hindsight dataplane by container name over the shared-services net.
+      # api_url carries /api (server HINDSIGHT_API_BASE_PATH); the REST client appends /v1/... .
+      # NOTE: `memory.provider: hindsight` must be set ONCE in config.yaml (no env selector exists)
+      # — see docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md §6 and §10.
+      - HINDSIGHT_MODE=local_external
+      - HINDSIGHT_API_URL=http://hindsight:8888/api
+      - HINDSIGHT_BANK_ID=hermes
+      - HINDSIGHT_API_KEY=${HINDSIGHT_API_KEY}
+    volumes:
+      - /mnt/spool/apps/data/hermes/gateway:/opt/data
+```
+
+- [ ] **Step 4: Attach `hermes-gateway` to `shared-services`**
+
+Edit `stacks/hermes.yaml`. Find (lines 96-100 — this `start_period: 60s` anchor is unique to the gateway; camofox's is `30s`):
+
+```yaml
+      start_period: 60s
+    networks:
+      - hermes-net
+
+  open-webui:
+```
+
+Replace with:
+
+```yaml
+      start_period: 60s
+    networks:
+      - hermes-net
+      - shared-services
+
+  open-webui:
+```
+
+- [ ] **Step 5: Add `shared-services` to the top-level `networks:` block**
+
+Edit `stacks/hermes.yaml`. Find the top-level block (lines 182-183):
+
+```yaml
+networks:
+  hermes-net:
+```
+
+Replace with:
+
+```yaml
+networks:
+  hermes-net:
+  # Created out-of-band on the host: `docker network create shared-services`.
+  # Shared with the hindsight stack so hermes-gateway resolves `hindsight` by name.
+  shared-services:
+    external: true
+```
+
+- [ ] **Step 6: Validate and re-run the assertion — expect PASS**
+
+```bash
+./scripts/validate-stack.sh hermes
+docker-compose -f stacks/hermes.yaml config 2>/dev/null | grep -q 'hindsight:8888/api' && echo API_OK || echo API_MISSING
+docker-compose -f stacks/hermes.yaml config 2>/dev/null \
+  | awk '/^  hermes-gateway:/{f=1} f&&/networks:/{p=1} p&&/shared-services/{print "gateway-on-shared-services"; exit}'
+```
+
+Expected:
+- `Validation successful for stacks/hermes.yaml` (unset-variable warnings on stderr are fine).
+- `API_OK`
+- `gateway-on-shared-services`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add stacks/hermes.yaml
+git commit -m "$(printf 'feat(hermes): wire gateway to Hindsight memory over shared-services\n\nPhase-2: native hindsight provider (local_external). Adds HINDSIGHT_*\nenv (api_url=http://hindsight:8888/api, bank=hermes), joins gateway to\nthe shared-services net, and documents the new HINDSIGHT_API_KEY var.\nProvider is switched on once via config.yaml at deploy (spec §10).\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 3: Reconcile prior design docs with the as-built Phase-2 state
+
+Both prior specs list Hindsight as deferred/out-of-scope. Add a dated one-line pointer so the doc set stays honest (matches the repo's as-built reconciliation convention). This task changes only Markdown; there is no `validate-stack.sh` step.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md`
+- Modify: `docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md`
+
+- [ ] **Step 1: Locate the Hindsight/Phase-2 mentions**
+
+```bash
+grep -n -i 'hindsight' docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md | head
+grep -n -i 'hindsight' docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md | head
+```
+
+Expected: at least one hit in each (the stealth doc's §12 Phase-2 section; the gateway-port doc's out-of-scope line).
+
+- [ ] **Step 2: Add the as-built pointer to the stealth-browser design doc**
+
+In `docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md`, at the start of the Hindsight/§12 Phase-2 section (immediately after its heading line found in Step 1), insert this blockquote line on its own line:
+
+```markdown
+> **As-built update (2026-07-01):** Implemented. See `docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md` and `docs/superpowers/plans/2026-07-01-hermes-hindsight-phase2.md`. Wired via the native `hindsight` provider (`local_external`, `http://hindsight:8888/api`) over the `shared-services` network.
+```
+
+- [ ] **Step 3: Add the as-built pointer to the gateway-port design doc**
+
+In `docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md`, on the line immediately after the Hindsight out-of-scope mention found in Step 1, insert:
+
+```markdown
+> **As-built update (2026-07-01):** Phase-2 Hindsight memory now implemented — see `docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md`.
+```
+
+- [ ] **Step 4: Sanity-check both edits render**
+
+```bash
+grep -n 'As-built update (2026-07-01)' docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md
+```
+
+Expected: one match in each file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md
+git commit -m "$(printf 'docs(hermes): mark Phase-2 Hindsight as implemented in prior specs\n\nAdds dated as-built pointers to the 2026-07-01 Phase-2 spec/plan in the\nstealth-browser and gateway-port design docs.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Deploy (host, manual — outside this plan)
+
+After the three tasks land in the repo, deploy per spec §10:
+
+1. `docker network create shared-services` (idempotent).
+2. Read `HINDSIGHT_API_TENANT_API_KEY` from `/mnt/spool/apps/config/hindsight/env`; set it as `HINDSIGHT_API_KEY` on the hermes Portainer stack.
+3. Redeploy the hindsight stack; verify internal DNS (`docker exec hindsight getent hosts hindsight-db`).
+4. Redeploy the hermes stack.
+5. `docker exec hermes-gateway hermes config set memory.provider hindsight` (config-file-only; restart gateway if it caches config at boot).
+6. Run spec §9 checks: `GET /api/version` from the gateway, `hermes config get memory.provider` → `hindsight`, retain→recall round-trip against the auto-created `hermes` bank.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2 shared network → Task 1 (hindsight side) + Task 2 Steps 4-5 (hermes side). ✓
+- §5.2 hermes env + activation → Task 2 Steps 2-3 (env + header); activation is deploy-step (config.yaml only, §6). ✓
+- §5.3 hindsight network attach (re-list `default`) → Task 1 Steps 2-3. ✓
+- §6 api_url/activation/bank facts → encoded in env values (Task 2) + Deploy section + spec. ✓
+- §7 fallback → documented in spec; not a repo task (correct — only used if native fails at deploy). ✓
+- §9 validation / §10 runbook → Deploy section. ✓
+- Doc reconciliation (repo convention) → Task 3. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows exact before/after YAML and exact commands with expected output. ✓
+
+**Type/name consistency:** `shared-services`, `HINDSIGHT_API_URL=http://hindsight:8888/api`, `HINDSIGHT_BANK_ID=hermes`, `HINDSIGHT_API_KEY`, `memory.provider: hindsight` used identically across tasks and match the spec. ✓

--- a/docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md
+++ b/docs/superpowers/specs/2026-06-30-hermes-gateway-openwebui-port-design.md
@@ -20,6 +20,7 @@ Replace the fragile third-party UI + source-volume bridge with the **official fi
 ## 2. Non-goals / out of scope (Phase 2, unchanged)
 
 - Hindsight semantic memory provider (Hermes built-in memory covers v1).
+  - **As-built update (2026-07-01):** Phase-2 Hindsight memory now implemented — see `docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md`.
 - 1Password agent-driven login (human noVNC login + persistent camofox profile remains the credential model).
 - Messaging adapters (Telegram/Discord/Slack/WhatsApp) — the gateway runs **API-server-only**; adapters stay opt-in/off.
 - Residential egress proxy for camofox.

--- a/docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md
+++ b/docs/superpowers/specs/2026-06-30-hermes-stealth-browser-stack-design.md
@@ -425,6 +425,8 @@ complex than the §6 host-file Docker-secrets approach, with no security gain. K
 
 ## 12. Persistent memory via Hindsight — optional, Phase 2
 
+> **As-built update (2026-07-01):** Implemented. See `docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md` and `docs/superpowers/plans/2026-07-01-hermes-hindsight-phase2.md`. Wired via the native `hindsight` provider (`local_external`, `http://hindsight:8888/api`) over the `shared-services` network.
+
 **Default (Phase 1): Hermes' built-in memory.** Hermes ships always-on Markdown memory (`SOUL.md`,
 `memories/MEMORY.md`, `memories/USER.md`) under `~/.hermes`, char-capped (~800 + ~500 tokens) and
 curated by the model. Enough for a working agent (identity, preferences, durable facts); it cannot be

--- a/docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md
@@ -1,0 +1,197 @@
+# Hermes ↔ Hindsight Memory (Phase 2) — Design Spec
+
+- **Date:** 2026-07-01
+- **Status:** Approved (brainstorm)
+- **Stack files:** `stacks/hermes.yaml` (modify), `stacks/hindsight.yaml` (modify — network attach only)
+- **Author:** brainstormed with Claude Code (ultracode)
+- **Implements:** the Phase‑2 Hindsight enhancement deferred by `2026-06-30-hermes-stealth-browser-stack-design.md` (§12) and `2026-06-30-hermes-gateway-openwebui-port-design.md` (§2). Built‑in Markdown memory carried over unchanged and stays active.
+
+---
+
+## 1. Goal & what changes
+
+**Augment — not replace —** Hermes' always‑on built‑in Markdown memory (`SOUL.md`, `memories/MEMORY.md`, `memories/USER.md` under `HERMES_HOME`) with the self‑hosted **Hindsight** stack, for large‑scale semantic recall, fact extraction, and cross‑session learning that a char‑capped Markdown store can't provide.
+
+- **Before:** `hermes-gateway` runs the agent in‑process with **zero** memory/MCP wiring; the two stacks (`hermes`, `hindsight`) live on **isolated** Docker networks and cannot reach each other by name.
+- **After:** Hermes' **native `hindsight` memory provider** (`mode=local_external`) reaches the Hindsight dataplane **server‑side** over **REST** at `http://hindsight:8888/api` via a **new shared external Docker network `shared-services`**. Automatic pre‑turn recall is injected into the system prompt and post‑turn `retain` persists to a dedicated `hermes` bank; `hindsight_recall`/`retain`/`reflect` tools are also exposed. Built‑in Markdown memory remains active alongside.
+
+> **Transport note:** the native provider uses Hindsight's **REST client**, not MCP. It appends `/v1/default/banks/<bank>/…` to the configured `api_url`; the `/api` segment matches the server's `HINDSIGHT_API_BASE_PATH=/api`. The `/mcp/<bank>/` endpoint is only relevant to the §7 `mcp_servers` fallback.
+
+**Why native provider (not raw MCP):** it's the first‑class, turn‑lifecycle integration (background prefetch/recall + conversation sync/retain) both design docs recommend. A raw `mcp_servers` entry is kept as a **documented fallback** only (§7).
+
+**Why the shared network (not the public URL):** the agent is in‑process in `hermes-gateway`, so the backend must be reachable *from that container*. The public `hindsight.alekseev.us` is a dead end — it sits behind Cloudflare Access (blocks a programmatic agent) and its cloudflared rule only proxies `^/api/(mcp|v1|…)`, so the real MCP path `/mcp/<bank>/` would 404. Container‑name routing over a shared Docker network bypasses both.
+
+## 2. Non‑goals / out of scope
+
+- Replacing or disabling built‑in Markdown memory (it's always‑on and stays active; §5.2 keeps the `memory` tool enabled).
+- Changing Hindsight's own behavior, models, embeddings, DB, or LLM wiring — the only edit to `hindsight.yaml` is a network attach (§5.3).
+- Per‑session or per‑user bank isolation via `bank_id_template` — we pin a **single** `hermes` bank (revisit later if multi‑agent isolation is needed).
+- Publishing any host port; all cross‑stack traffic stays on the internal shared network. External human access remains cloudflared + Cloudflare Access, unchanged.
+- Fixing the unrelated pinned‑image issues (duplicate‑`tool_use`‑id transcript bug; `config.yaml`/OpenRouter provider default). Noted as risks (§11), handled elsewhere.
+
+## 3. Key decisions (and why)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Integration mechanism | **Native `hindsight` provider** (`mode=local_external`) | First‑class turn‑lifecycle recall/retain + `reflect` synthesis; matches both design docs. `mcp_servers` kept as fallback only. |
+| Cross‑stack networking | **Shared external network `shared-services`** | Cleanest, reusable; container‑name routing survives IP churn; no internet, no Cloudflare Access, no `/api/mcp` 404. |
+| Hindsight endpoint | **`http://hindsight:8888/api`** by container name (REST) | Native provider is REST; client appends `/v1/default/banks/<bank>/…`; `/api` matches server `HINDSIGHT_API_BASE_PATH=/api`. Reached only over `shared-services`. |
+| Connection config surface | **Portainer `${VAR}` env on `hermes-gateway`** (env overrides file) | Matches the stack's existing zero‑docker‑secrets pattern; 12‑factor; survives image upgrades without seeding files. |
+| Provider activation | **`memory.provider: hindsight`** persisted in `HERMES_HOME/config.yaml` | **Config‑file‑only — no env var selects the provider** (source‑confirmed). Set once via `hermes config set memory.provider hindsight` / `hermes memory setup`; persists in the `/opt/data` volume. |
+| Tenant key | **New Portainer var `HINDSIGHT_API_KEY`**, value copied from the host Hindsight secret | Consistent with the current hermes stack (no docker secrets today). |
+| Memory bank | **Single pinned bank `hermes`** (`HINDSIGHT_BANK_ID=hermes`) | Isolates this agent's memory from other Hindsight tenants; simple. |
+| Built‑in memory | **Kept enabled alongside Hindsight** | Additive design; built‑in is always‑on and needs no infra. Option to `hermes tools disable memory` if the model over‑prefers it. |
+
+## 4. Architecture
+
+Two Portainer stacks on the same host, bridged by one **external** Docker network. `hermes-gateway` gains a second network attachment; the `hindsight` service gains one. Nothing else moves; nothing is published to the host.
+
+```
+   ┌─────────────────────── hermes stack (hermes-net) ───────────────────────┐
+   │  open-webui ──/v1──▶ hermes-gateway  ──browser tools──▶ camofox          │
+   │                       (agent in‑process; gateway run)                    │
+   │                       HERMES_HOME=/opt/data                              │
+   │                       native hindsight provider ─┐                       │
+   └───────────────────────────────────────────────── │ ─────────────────────┘
+                                                       │  http://hindsight:8888/api (REST)
+                            shared-services  ◀─────────┘  (external: true)
+                                (bridge)     ─────────┐
+   ┌──────────────────────── hindsight stack ──────── │ ─────────────────────┐
+   │  hindsight ◀──────────────────────────────────────┘                     │
+   │   :8888 dataplane API — REST /api/v1 (native); /mcp/<bank>/ = fallback   │
+   │   :9999 control plane UI                                                 │
+   │   ├─ hindsight-db (vchord pg18)   ├─ hindsight-litellm :4000             │
+   │   ├─ hindsight-tei-embed          └─ hindsight-tei-reranker              │
+   │   (all on the stack's default project network — unchanged)              │
+   └──────────────────────────────────────────────────────────────────────────┘
+```
+
+## 5. Component specifications
+
+### 5.1 `shared-services` network (host + both stacks)
+
+- **Host, once:** `docker network create shared-services` (a plain bridge; external to both compose projects).
+- Declared in **both** stacks top‑level as:
+  ```yaml
+  networks:
+    shared-services:
+      external: true
+  ```
+
+### 5.2 `stacks/hermes.yaml` — modify `hermes-gateway`
+
+1. **Network attach** — join both networks:
+   ```yaml
+   services:
+     hermes-gateway:
+       networks:
+         - hermes-net
+         - shared-services
+   ```
+   (Every other service stays on `hermes-net` only. Add the top‑level `shared-services` block from §5.1.)
+2. **Connection env** (Portainer `${VAR}` pattern; env overrides the JSON config file):
+   ```yaml
+       environment:
+         HINDSIGHT_MODE: local_external
+         HINDSIGHT_API_URL: http://hindsight:8888/api   # /api = server HINDSIGHT_API_BASE_PATH; client appends /v1/...
+         HINDSIGHT_BANK_ID: hermes
+         HINDSIGHT_API_KEY: ${HINDSIGHT_API_KEY}         # == server's HINDSIGHT_API_TENANT_API_KEY
+   ```
+3. **Provider activation** — set `memory.provider: hindsight` once via `hermes config set memory.provider hindsight` (or `hermes memory setup` → hindsight); persists to `/opt/data/config.yaml`. **Required — no env var can select the provider** (§6).
+4. **Built‑in memory** — left enabled (no change). Optional post‑deploy tuning: `hermes tools disable memory` if recall quality suffers from tool competition.
+5. **New required Portainer var:** `HINDSIGHT_API_KEY` — its value must equal the Hindsight server's `HINDSIGHT_API_TENANT_API_KEY` (documented in the stack header comment alongside the existing required vars).
+
+### 5.3 `stacks/hindsight.yaml` — modify the `hindsight` service only
+
+The `hindsight` service currently declares **no** `networks:` key (it's implicitly on the project default network). Adding an explicit list means we must **re‑list `default`** so its siblings (`hindsight-db`, `hindsight-litellm`, `hindsight-tei-*`) stay reachable:
+
+```yaml
+services:
+  hindsight:
+    networks:
+      - default
+      - shared-services
+networks:
+  shared-services:
+    external: true
+```
+
+No other Hindsight service is touched; `default` remains auto‑created for db/litellm/tei.
+
+## 6. Provider activation & config resolution
+
+Config resolution order (highest wins): **`HINDSIGHT_*` env** → `HERMES_HOME/hindsight/config.json` → provider defaults. The provider *selection* (`memory.provider`) lives separately in `HERMES_HOME/config.yaml`. The following were resolved from source (`NousResearch/hermes-agent` plugin + `vectorize-io/hindsight` client/server) at **HIGH confidence**:
+
+- **Q1 — `api_url` shape → `http://hindsight:8888/api`.** Hermes passes `api_url` verbatim as the client `base_url` (`plugins/memory/hindsight/__init__.py:1283,1057`); the generated client appends its own resource paths — `POST /v1/default/banks/<bank>/memories` (retain), `.../memories/recall`, `.../reflect`, and an init‑time `GET /version` probe. The client never inserts `/api`; that prefix is the **server's** `HINDSIGHT_API_BASE_PATH=/api` (FastAPI `root_path`), so `api_url` must carry it. Net path for retain: `http://hindsight:8888/api/v1/default/banks/hermes/memories`.
+  *Deploy verify (the exact probe Hermes runs on init):*
+  ```
+  docker exec hermes-gateway sh -c 'curl -fsS -H "Authorization: Bearer $HINDSIGHT_API_KEY" http://hindsight:8888/api/version'
+  ```
+- **Q2 — activation → `memory.provider: hindsight` in `config.yaml`, config‑file‑only.** The gateway reads the provider via `cfg_get(cfg, "memory", "provider")` (`gateway/run.py:14536`), a pure config‑file lookup with **no env fallback** — there is no `HERMES_MEMORY_PROVIDER` (source‑confirmed). Set once: `hermes config set memory.provider hindsight` (or `hermes memory setup`). The `HINDSIGHT_*` env vars only configure the provider *after* it is selected.
+  *Deploy verify:* `docker exec hermes-gateway hermes config get memory.provider` → `hindsight`.
+- **Q3 — bank provisioning → auto‑created on first write; no pre‑creation.** Official 0.8 docs: *"You don't need to pre‑create a bank. Hindsight will automatically create it… when you first use it."* This holds under the `ApiKeyTenantExtension` (it validates the Bearer key and pins the `public` schema; it does not change auto‑create or the `default` namespace segment). Hermes' default `bank_id` is `hermes`.
+  *Deploy verify (end‑to‑end retain against the tenant‑authed instance):*
+  ```
+  docker exec hermes-gateway sh -c 'curl -fsS -X POST -H "Authorization: Bearer $HINDSIGHT_API_KEY" -H "Content-Type: application/json" -d "{\"items\":[{\"content\":\"deploy smoke test\"}]}" http://hindsight:8888/api/v1/default/banks/hermes/memories'
+  ```
+
+## 7. Fallback — raw `mcp_servers` (documented, not wired)
+
+If `local_external` misbehaves on the pinned `hermes-agent` digest, register Hindsight as a plain MCP server in `HERMES_HOME/config.yaml`:
+
+```yaml
+mcp_servers:
+  hindsight:
+    url: http://hindsight:8888/mcp/hermes/     # bank in path; see base-path caveat below
+    headers:
+      Authorization: "Bearer ${HINDSIGHT_API_KEY}"
+    tools:
+      include: [recall, retain, sync_retain, reflect, get_memory, list_memories]
+    timeout: 120
+```
+
+Trade‑off: no automatic pre‑turn recall injection (model must call tools), but path/auth are fully documented and `sync_retain` gives read‑after‑write.
+
+**Base‑path caveat:** unlike the REST client (§6 Q1), the MCP mount's interaction with `HINDSIGHT_API_BASE_PATH=/api` is unverified — the endpoint may be `/mcp/hermes/` or `/api/mcp/hermes/`. Only relevant if the native provider fails; confirm the working path at deploy before wiring the fallback.
+
+## 8. Error handling & gotchas
+
+- **Async retain** — `retain_async=true` (default): a recall immediately after a write may miss. Acceptable for background learning; use `sync_retain` (fallback tools) where read‑after‑write matters.
+- **Timeouts** — Hindsight's server LLM timeout is **600s** in this deployment (`HINDSIGHT_API_LLM_TIMEOUT=600`). Keep Hermes' client/MCP timeout generous (≥ server window); the fallback `mcp_servers` block starts at 120 and should be raised if writes time out.
+- **Tenant key extraction** — the real key value lives on the host in `/mnt/spool/apps/config/hindsight/env` (docker secret `hindsight_env`), under the var **`HINDSIGHT_API_TENANT_API_KEY`**. The runbook copies that value into the new `HINDSIGHT_API_KEY` Portainer var on the hermes stack. The client sends it as `Authorization: Bearer <key>`.
+- **Startup ordering** — cross‑stack, so no compose `depends_on`. Bring `hindsight` up first; the native provider tolerates a briefly‑absent backend (recall degrades gracefully), but verify after both are up.
+- **Network side‑effects** — attaching `hindsight` to a second network must not break its internal DNS; §5.3 re‑lists `default` precisely to preserve it. Validate `hindsight` still resolves `hindsight-db`/`hindsight-litellm` after the edit.
+- **Known unrelated image bug** — duplicate‑`tool_use`‑id transcript wedging on the pinned digest; watch long chats after adding a tool provider (out of scope to fix here).
+
+## 9. Validation
+
+- **Static:** `./scripts/validate-stack.sh hermes` and `./scripts/validate-stack.sh hindsight` (both must pass `docker compose config`).
+- **Runtime (host, after redeploy):**
+  1. Reachability + api_url: `docker exec hermes-gateway sh -c 'curl -fsS -H "Authorization: Bearer $HINDSIGHT_API_KEY" http://hindsight:8888/api/version'` — 200 confirms container‑name routing over `shared-services` and the `/api` base path.
+  2. Provider selected: `docker exec hermes-gateway hermes config get memory.provider` → `hindsight`; `hermes memory status` → connected.
+  3. Round‑trip: chat turn stating a durable fact → later turn recalls it; confirm a `retain` landed in the `hermes` bank (Control Plane `:9999`), and/or run the §6 Q3 retain curl.
+
+## 10. Host runbook (manual — assistant cannot reach the host)
+
+1. `docker network create shared-services` (idempotent; skip if it exists).
+2. Read `HINDSIGHT_API_TENANT_API_KEY` from `/mnt/spool/apps/config/hindsight/env`.
+3. In Portainer, add `HINDSIGHT_API_KEY=<that value>` to the **hermes** stack env.
+4. Deploy the updated `hindsight` stack (network attach) — verify internal DNS intact (`docker exec hindsight getent hosts hindsight-db`).
+5. Deploy the updated `hermes` stack (env + network attach).
+6. Set the provider (required, config‑file‑only): `docker exec hermes-gateway hermes config set memory.provider hindsight` (or `hermes memory setup` → hindsight). Restart the gateway if it caches config at boot.
+7. Run the §9 runtime checks. Bank `hermes` auto‑creates on first retain (no pre‑creation). If `local_external` fails, switch to the §7 `mcp_servers` fallback.
+
+## 11. Risks
+
+- **Version skew on the pinned digest** — §6 was verified against upstream `main`; the pinned `hermes-agent` digest (`…f670f417`) may ship an older provider or `hindsight-client` where paths differ. *Mitigation:* §9 step 1 (`/api/version`) + step 2 (`memory status`) catch it immediately; §7 fallback covers a hard miss.
+- **Static OAuth token expiry** (pre‑existing) — unrelated to memory but a silent‑outage risk for the daemon.
+- **Tool competition** — model may prefer the built‑in `memory` tool over Hindsight; mitigated by keeping auto‑recall on and, if needed, `hermes tools disable memory`.
+
+## 12. Validate‑at‑deploy checklist
+
+- [ ] `shared-services` network exists; both stacks attach without error.
+- [ ] `hindsight` still resolves its siblings after the network edit.
+- [ ] `GET http://hindsight:8888/api/version` from `hermes-gateway` returns 200 (routing + `/api` base path).
+- [ ] `hermes config get memory.provider` → `hindsight`; `hermes memory status` connected.
+- [ ] retain → recall round‑trip works against the auto‑created `hermes` bank.
+- [ ] (Only if falling back) confirmed the working MCP path re: the `/api` base‑path caveat (§7).

--- a/stacks/hermes.yaml
+++ b/stacks/hermes.yaml
@@ -10,6 +10,7 @@
 #   HERMES_DASHBOARD_SECRET   - dashboard token-signing key (openssl rand -base64 32)
 #   ANTHROPIC_TOKEN           - Claude OAuth setup-token (sk-ant-oat-...)
 #   HERMES_TUNNEL_ID          - Cloudflare tunnel UUID
+#   HINDSIGHT_API_KEY         - Hindsight tenant key (== server HINDSIGHT_API_TENANT_API_KEY); Phase-2 memory
 # Nothing published to host; only cloudflared reaches origins, gated by one Cloudflare Access app.
 
 services:
@@ -86,6 +87,15 @@ services:
       - CAMOFOX_ADOPT_EXISTING_TAB=true
       # Claude via OAuth setup-token (see spec §9 for the daemon-expiry runbook).
       - ANTHROPIC_TOKEN=${ANTHROPIC_TOKEN}
+      # Phase-2 Hindsight semantic memory — AUGMENTS (does not replace) built-in Markdown memory.
+      # Reaches the self-hosted hindsight dataplane by container name over the shared-services net.
+      # api_url carries /api (server HINDSIGHT_API_BASE_PATH); the REST client appends /v1/... .
+      # NOTE: `memory.provider: hindsight` must be set ONCE in config.yaml (no env selector exists)
+      # — see docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md §6 and §10.
+      - HINDSIGHT_MODE=local_external
+      - HINDSIGHT_API_URL=http://hindsight:8888/api
+      - HINDSIGHT_BANK_ID=hermes
+      - HINDSIGHT_API_KEY=${HINDSIGHT_API_KEY}
     volumes:
       - /mnt/spool/apps/data/hermes/gateway:/opt/data
     healthcheck:
@@ -96,6 +106,7 @@ services:
       start_period: 60s
     networks:
       - hermes-net
+      - shared-services
 
   open-webui:
     restart: unless-stopped
@@ -181,3 +192,7 @@ configs:
 
 networks:
   hermes-net:
+  # Created out-of-band on the host: `docker network create shared-services`.
+  # Shared with the hindsight stack so hermes-gateway resolves `hindsight` by name.
+  shared-services:
+    external: true

--- a/stacks/hindsight.yaml
+++ b/stacks/hindsight.yaml
@@ -78,6 +78,12 @@ services:
       hindsight-db:
         condition: service_healthy
     restart: unless-stopped
+    # Phase-2: also join the host-created shared-services net so the hermes stack can
+    # reach this dataplane by container name (http://hindsight:8888/api). `default` is
+    # re-listed explicitly so siblings (hindsight-db, litellm, tei-*) stay reachable.
+    networks:
+      - default
+      - shared-services
 
   hindsight-db:
     image: ghcr.io/tensorchord/vchord-suite:pg18-20260401
@@ -282,3 +288,9 @@ secrets:
     file: /mnt/spool/apps/config/hindsight/secrets/db_password
   hindsight_env:
     file: /mnt/spool/apps/config/hindsight/env
+
+networks:
+  # Created out-of-band on the host: `docker network create shared-services`.
+  # Shared with the hermes stack so hermes-gateway resolves `hindsight` by name.
+  shared-services:
+    external: true


### PR DESCRIPTION
## Summary
- Wires Hermes' **native `hindsight` memory provider** (`local_external`) to the self-hosted Hindsight dataplane over a new shared external Docker network `shared-services`, reached server-side by container name. **Augments** (does not replace) Hermes' built-in Markdown memory.
- **`stacks/hindsight.yaml`**: attach the `hindsight` service to `shared-services` (`default` re-listed so internal DNS to db/litellm/tei is preserved). No behavior change to Hindsight.
- **`stacks/hermes.yaml`**: add `HINDSIGHT_*` env on `hermes-gateway` (`api_url=http://hindsight:8888/api`, `bank=hermes`, `mode=local_external`), join the gateway to `shared-services`, and document the new required `HINDSIGHT_API_KEY` Portainer var.
- **Docs**: as-built pointers added to the prior stealth-browser and gateway-port design docs.
- Design + implementation plan (with the source-verified REST/config surface) already on `master`: `docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md`, `docs/superpowers/plans/2026-07-01-hermes-hindsight-phase2.md`.

Key source-verified facts baked in: `api_url` carries `/api` (server `HINDSIGHT_API_BASE_PATH`; REST client appends `/v1/...`); provider is switched on **only** via `config.yaml` (no env selector); the `hermes` bank auto-creates on first retain; `HINDSIGHT_API_KEY` == server `HINDSIGHT_API_TENANT_API_KEY`.

## Test Plan
- [x] `./scripts/validate-stack.sh hermes` — Validation successful
- [x] `./scripts/validate-stack.sh hindsight` — Validation successful
- [x] Rendered config: gateway on `shared-services`; `HINDSIGHT_API_URL=http://hindsight:8888/api`; hindsight service on `default` + `shared-services`
- [ ] Host: `docker network create shared-services`; set `HINDSIGHT_API_KEY` (== server `HINDSIGHT_API_TENANT_API_KEY`) in the hermes Portainer stack
- [ ] Redeploy both stacks; `docker exec hindsight getent hosts hindsight-db` (internal DNS intact)
- [ ] `docker exec hermes-gateway hermes config set memory.provider hindsight`
- [ ] `GET http://hindsight:8888/api/version` from the gateway → 200; `hermes memory status` connected
- [ ] retain → recall round-trip against the auto-created `hermes` bank

🤖 Generated with [Claude Code](https://claude.com/claude-code)