### PR TITLE
fix(hermes): seal read-only venv for Hindsight memory + record as-built findings

### DIFF
--- a/docs/superpowers/plans/2026-07-01-hermes-hindsight-phase2.md
+++ b/docs/superpowers/plans/2026-07-01-hermes-hindsight-phase2.md
@@ -183,6 +183,10 @@ Replace with:
       - HINDSIGHT_API_URL=http://hindsight:8888/api
       - HINDSIGHT_BANK_ID=hermes
       - HINDSIGHT_API_KEY=${HINDSIGHT_API_KEY}
+      # Seal the read-only app venv: hindsight-client is baked in and pinned ==0.6.1;
+      # never let the runtime lazy-install into /opt/hermes/.venv (uid 1000, read-only),
+      # and NEVER upgrade the client. See the spec's As-built operational notes.
+      - HERMES_DISABLE_LAZY_INSTALLS=1
     volumes:
       - /mnt/spool/apps/data/hermes/gateway:/opt/data
 ```
@@ -311,8 +315,13 @@ After the three tasks land in the repo, deploy per spec §10:
 2. Read `HINDSIGHT_API_TENANT_API_KEY` from `/mnt/spool/apps/config/hindsight/env`; set it as `HINDSIGHT_API_KEY` on the hermes Portainer stack.
 3. Redeploy the hindsight stack; verify internal DNS (`docker exec hindsight getent hosts hindsight-db`).
 4. Redeploy the hermes stack.
-5. `docker exec hermes-gateway hermes config set memory.provider hindsight` (config-file-only; restart gateway if it caches config at boot).
+5. `docker exec hermes-gateway hermes config set memory.provider hindsight` (config-file-only; restart gateway if it caches config at boot). **Do not run `hermes memory setup`'s dependency install / ignore its "Install failed" warning** — `hindsight-client` is baked in (`==0.6.1`) and the venv is read-only, so the warning is cosmetic (see spec As-built notes).
 6. Run spec §9 checks: `GET /api/version` from the gateway, `hermes config get memory.provider` → `hindsight`, retain→recall round-trip against the auto-created `hermes` bank.
+
+**Operational guardrails (verified live 2026-07-01):**
+- **Never upgrade `hindsight-client`** — pinned `==0.6.1`; any drift wedges runtime retain. `HERMES_DISABLE_LAZY_INSTALLS=1` (in `hermes.yaml`) enforces use of the baked client and makes the plugin fail-fast instead of emitting `ensurepip` errors.
+- Diagnostics via `sudo docker exec` run as **root** (can write the venv); the daemon runs as **uid 1000** (cannot) — a manual install "working" can mask the real daemon behavior.
+- The Hermes tenant key can list the whole Hindsight tenant (`claude-code::*` banks); isolation from Claude Code's memory is by `bank_id` (`hermes`) only.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-01-hermes-hindsight-phase2-design.md
@@ -1,10 +1,22 @@
 # Hermes ↔ Hindsight Memory (Phase 2) — Design Spec
 
 - **Date:** 2026-07-01
-- **Status:** Approved (brainstorm)
+- **Status:** Implemented & verified live on `silverstone` 2026-07-01 (PR #86). See the As-built notes below.
 - **Stack files:** `stacks/hermes.yaml` (modify), `stacks/hindsight.yaml` (modify — network attach only)
 - **Author:** brainstormed with Claude Code (ultracode)
 - **Implements:** the Phase‑2 Hindsight enhancement deferred by `2026-06-30-hermes-stealth-browser-stack-design.md` (§12) and `2026-06-30-hermes-gateway-openwebui-port-design.md` (§2). Built‑in Markdown memory carried over unchanged and stays active.
+
+---
+
+## As-built operational notes (verified live 2026-07-01, PR #86)
+
+Deployed and verified end-to-end on `silverstone`: a chat turn's retain → server-side fact extraction → recall round-trip against the `hermes` bank all succeed. Field-learned facts — these **override any conflicting assumption below**:
+
+- **`hindsight-client` is baked into the image and pinned EXACTLY `==0.6.1`** (`tools/lazy_deps.py`). It already satisfies the plugin, so **nothing needs installing**. **Never upgrade or downgrade it** — the plugin re-checks the version on every `_get_client`; any version ≠ 0.6.1 triggers a runtime reinstall attempt that **fails and silently wedges retain** (no bank, no memory). *(This bit us once: an `--upgrade` to 0.8.4 during debugging broke retain until 0.6.1 was restored.)*
+- **The app venv `/opt/hermes/.venv` is root-owned and read-only to the `hermes` (uid 1000) daemon.** Runtime `pip`/`uv` installs into it fail by design. So `hermes memory setup`'s "⚠ Install failed … hindsight-client" warning is **cosmetic and protective** (it can't corrupt the pinned client) — **ignore it; don't try to make it succeed.** Also: `sudo docker exec` runs as **root** (can write the venv) while the daemon runs as **uid 1000** (cannot) — a classic "works when I test it, fails in the daemon" trap.
+- **`HERMES_DISABLE_LAZY_INSTALLS=1` is set on `hermes-gateway`** (the Nous image is meant to set it). It makes the plugin use the baked client and fail-fast instead of emitting `ensurepip` errors. No-op when the pin is satisfied.
+- **Provider is configured via `config.yaml` + env; do not re-run the wizard** — `memory.provider: hindsight` is set and the `HINDSIGHT_*` env is supplied. (The wizard's default URL `http://localhost:8888` is wrong for us; env supplies `http://hindsight:8888/api`.)
+- **⚠ Tenant isolation:** the Hermes tenant key authenticates against the **whole Hindsight tenant** — it can list Claude Code's own banks (`claude-code::*`). Separation is by `bank_id` (`hermes`) convention **only**, not hard tenant isolation. Use a separate tenant key/schema for hard separation.
 
 ---
 
@@ -96,6 +108,7 @@ Two Portainer stacks on the same host, bridged by one **external** Docker networ
          HINDSIGHT_API_URL: http://hindsight:8888/api   # /api = server HINDSIGHT_API_BASE_PATH; client appends /v1/...
          HINDSIGHT_BANK_ID: hermes
          HINDSIGHT_API_KEY: ${HINDSIGHT_API_KEY}         # == server's HINDSIGHT_API_TENANT_API_KEY
+         HERMES_DISABLE_LAZY_INSTALLS: "1"               # seal read-only venv; use baked hindsight-client==0.6.1 (never upgrade)
    ```
 3. **Provider activation** — set `memory.provider: hindsight` once via `hermes config set memory.provider hindsight` (or `hermes memory setup` → hindsight); persists to `/opt/data/config.yaml`. **Required — no env var can select the provider** (§6).
 4. **Built‑in memory** — left enabled (no change). Optional post‑deploy tuning: `hermes tools disable memory` if recall quality suffers from tool competition.
@@ -183,7 +196,7 @@ Trade‑off: no automatic pre‑turn recall injection (model must call tools), b
 
 ## 11. Risks
 
-- **Version skew on the pinned digest** — §6 was verified against upstream `main`; the pinned `hermes-agent` digest (`…f670f417`) may ship an older provider or `hindsight-client` where paths differ. *Mitigation:* §9 step 1 (`/api/version`) + step 2 (`memory status`) catch it immediately; §7 fallback covers a hard miss.
+- **Version skew on the pinned digest → RESOLVED (verified live 2026-07-01).** The digest ships `hindsight-client==0.6.1` (pinned) and the §6 REST paths match. The real hazard is *version drift*: the plugin re-checks the pin at runtime, and any non-0.6.1 version triggers a reinstall into the read-only venv that fails and wedges retain. Shipped mitigation: **never upgrade the client** + `HERMES_DISABLE_LAZY_INSTALLS=1` (see As-built notes). Never run runtime `uv pip install` against the client.
 - **Static OAuth token expiry** (pre‑existing) — unrelated to memory but a silent‑outage risk for the daemon.
 - **Tool competition** — model may prefer the built‑in `memory` tool over Hindsight; mitigated by keeping auto‑recall on and, if needed, `hermes tools disable memory`.
 
@@ -193,5 +206,6 @@ Trade‑off: no automatic pre‑turn recall injection (model must call tools), b
 - [ ] `hindsight` still resolves its siblings after the network edit.
 - [ ] `GET http://hindsight:8888/api/version` from `hermes-gateway` returns 200 (routing + `/api` base path).
 - [ ] `hermes config get memory.provider` → `hindsight`; `hermes memory status` connected.
-- [ ] retain → recall round‑trip works against the auto‑created `hermes` bank.
+- [x] retain → recall round‑trip works against the auto‑created `hermes` bank. *(verified 2026-07-01: `CORAL-OTTER-77` retained + recalled)*
+- [x] `HERMES_DISABLE_LAZY_INSTALLS=1` on the gateway; `hindsight-client` at baked `==0.6.1` (never upgraded).
 - [ ] (Only if falling back) confirmed the working MCP path re: the `/api` base‑path caveat (§7).

--- a/stacks/hermes.yaml
+++ b/stacks/hermes.yaml
@@ -96,6 +96,12 @@ services:
       - HINDSIGHT_API_URL=http://hindsight:8888/api
       - HINDSIGHT_BANK_ID=hermes
       - HINDSIGHT_API_KEY=${HINDSIGHT_API_KEY}
+      # Seal the read-only app venv. hindsight-client is baked into the image and
+      # pinned EXACTLY ==0.6.1; the runtime must NOT attempt a lazy pip install into
+      # /opt/hermes/.venv (root-owned, read-only to the uid-1000 daemon) — that fails
+      # and wedges retain. This is the Nous image's intended setting. NEVER upgrade the
+      # client: any version other than 0.6.1 triggers a reinstall attempt that fails.
+      - HERMES_DISABLE_LAZY_INSTALLS=1
     volumes:
       - /mnt/spool/apps/data/hermes/gateway:/opt/data
     healthcheck:


### PR DESCRIPTION
Follow-up to #86, after verifying Phase-2 Hindsight memory **end-to-end live** on silverstone (retain → server-side fact extraction → recall round-trip against the `hermes` bank).

## Summary
- **`stacks/hermes.yaml`**: add `HERMES_DISABLE_LAZY_INSTALLS=1` to `hermes-gateway`. The daemon runs as uid 1000 and `/opt/hermes/.venv` is root-owned/read-only, so the hindsight plugin's runtime lazy pip-install (to match its pinned `hindsight-client==0.6.1`) fails and **wedges retain**. The client is already baked into the image; disabling lazy installs (the Nous image's intended setting) makes the plugin use the baked client and fail-fast instead. No-op when the pin is satisfied.
- **Docs**: record the as-built operational findings in the spec + plan — `hindsight-client` is pinned `==0.6.1` and must **never** be upgraded (drift wedges retain), the read-only venv makes the `hermes memory setup` "Install failed" warning cosmetic/protective, and the tenant-isolation caveat (the Hermes key can list the whole Hindsight tenant; isolation is by `bank_id`).

## Why this matters
Root cause of a live retain failure was version drift: an `--upgrade` to `0.8.4` broke retain until `==0.6.1` was restored. This PR encodes the guardrail so it can't recur silently.

## Test plan
- [x] `./scripts/validate-stack.sh hermes` — Validation successful; `HERMES_DISABLE_LAZY_INSTALLS` renders as `"1"`.
- [x] End-to-end verified live: `hermes` bank auto-created; `CORAL-OTTER-77` retained and recalled.
- [ ] Redeploy the hermes stack in Portainer to pick up the env change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)