### PR TITLE
chore(hermes): bump hermes-gateway to v2026.7.1

### DIFF
--- a/stacks/hermes.yaml
+++ b/stacks/hermes.yaml
@@ -53,13 +53,7 @@ services:
     # First-party agent daemon. `gateway run` serves the OpenAI-compatible API on :8642 and
     # (HERMES_DASHBOARD=1) the dashboard on :9119 as a co-resident s6-rc service. s6 supervises
     # both, so a mis-start restarts in-container (no Docker crash-loop).
-    #
-    # Image pinned by digest: the ONLY published image carrying BOTH the camofox bearer-auth fix
-    # (#20476, merged to main 2026-06-29) and the gateway sleep/PATH crash fix (#36208). No release
-    # tag has both yet. STOPGAP — migrate to the first tag > v2026.6.19 containing commit babd916:
-    #   gh api repos/NousResearch/hermes-agent/compare/babd916...<tag> --jq '{status,behind_by}'
-    #   docker buildx imagetools inspect docker.io/nousresearch/hermes-agent:<tag> --format '{{.Manifest.Digest}}'
-    image: nousresearch/hermes-agent@sha256:c30340ee58dde86c284864b1016f474ec48c4a70ed49d24920cab083f670f417
+    image: nousresearch/hermes-agent:v2026.7.1
     container_name: hermes-gateway
     hostname: hermes-gateway
     command: gateway run


### PR DESCRIPTION
## Summary

- Pins `hermes-gateway` to `v2026.7.1` ("The Judgment Release") by tag
- Removes the STOPGAP digest comment — a proper release tag is now available
- v2026.7.1 is the first tag containing both required fixes (camofox bearer-auth #20476, gateway sleep/PATH #36208), plus the full P0/P1 sweep including credential-exfil hardening and duplicate tool_use bug fix

## Test plan

- [ ] Merge and redeploy the hermes stack in Portainer ("Re-pull image and redeploy")
- [ ] Verify gateway comes up healthy at hermes-dashboard.alekseev.us

🤖 Generated with [Claude Code](https://claude.com/claude-code)