### PR TITLE
fix(hermes): run op-init as root to fix Permission denied on named volume

### DIFF
--- a/stacks/hermes.yaml
+++ b/stacks/hermes.yaml
@@ -52,9 +52,12 @@ services:
     # One-shot init container: copies the op CLI binary from the official 1Password image
     # into the op-bin named volume, which hermes-gateway mounts at /usr/local/sbin.
     # Runs once at stack start and exits 0; hermes-gateway waits on service_completed_successfully.
+    # user: root required — 1password/op runs as opuser by default, which cannot write to the
+    # root-owned Docker named volume on first creation.
     image: 1password/op:2.34.1
     container_name: hermes-op-init
     restart: "no"
+    user: root
     entrypoint: ["cp", "/usr/local/bin/op", "/op-bin/op"]
     volumes:
       - op-bin:/op-bin


### PR DESCRIPTION
## Summary
- `1password/op` runs as `opuser` by default; the Docker-managed named volume `op-bin` is root-owned on first creation
- `cp /usr/local/bin/op /op-bin/op` failed with `Permission denied`, causing `op-init` to exit code 1 and blocking the whole stack
- Fix: add `user: root` to the `op-init` service so `cp` can write to the volume

## Test plan
- [ ] Redeploy hermes stack in Portainer
- [ ] `hermes-op-init` should exit 0 (green in Portainer)
- [ ] `hermes-gateway` should start normally
- [ ] `docker exec hermes-gateway op --version` should print the op version

🤖 Generated with [Claude Code](https://claude.com/claude-code)